### PR TITLE
ClassRegistry v2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
+  - '3.7'
 
 install:
   - pip install .
@@ -15,7 +16,7 @@ script:
 
 deploy:
   - on:
-      python: '3.6'
+      python: '3.7'
       tags: true
     provider: pypi
     distributions: 'bdist_wheel sdist'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,21 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
-install: pip install .
-script: python setup.py test
+
+install:
+  - pip install .
+  - pip install docutils  # Used to check package metadata.
+
+script:
+  - python setup.py check --strict --metadata --restructuredtext
+  - python setup.py test
+
 deploy:
-- on:
-    python: '3.6'
-    tags: true
-  provider: pypi
-  distributions: 'bdist_wheel sdist'
-  user: efl_phx
-  password:
-    secure: XE0fhr1GgWTUgV9ssVYJkO+V9AehYJy2kf5T9T7YB1SQMLOeqr0QcpUEbKYgObxVuAu6gXd0WbUYSMcayblrWQdVwZ9f8/wadU9JPT+3QNTy7/S/hcExbKhzT6+BWZF0t87ln5t4W7WpKqrenyPFtreCmtSkjMBT0IsZ1hTIDGZwlsbvD4Owxa4FdAIGi5vWldM6Ffm1/R5RFrLNpVECDnGUIfQhggjIcu9/4W/fSueTwLNaiwG+CmLFqoXrfjut1EplX+N2NTcLobGKCqztr5PcgplrcDWaZI7mRKAZCIB3z9xEjLNZz7FVVIgodi+A3/Ih3z4or2C1n5KIaAhmCgvoDdzLY4mqofd53uxc3QxNVnZbcg62J6kr4XzVxjdPGmaw0WJDWO3iCfdUZwXMSwXBUdTXXAymsE/AxpvyN+rTrPGxO2NuYYQqSOLC9PlWZU2jzmbCDPT0shrOQvNMSlKZ/D13nuWdWhKPAka/yKq/tZErc8nLEa2EwcHesu4Z8RAFymNnuv//e+HsVQLxOoO82zXwKCS0zM9HA7L5xiP94EPEcT6qHFCo8HclfAJKVrCZLe1DE1IejEryIEIrVQzuzeoBwR9Dbf8v2KHT0S00O6d55l+C7m0HaPNS+UqYEljj3UR2avgt101ILzTG2ILhsBHGsD9lz0Tep0XhEdc=
+  - on:
+      python: '3.6'
+      tags: true
+    provider: pypi
+    distributions: 'bdist_wheel sdist'
+    user: efl_phx
+    password:
+      secure: XE0fhr1GgWTUgV9ssVYJkO+V9AehYJy2kf5T9T7YB1SQMLOeqr0QcpUEbKYgObxVuAu6gXd0WbUYSMcayblrWQdVwZ9f8/wadU9JPT+3QNTy7/S/hcExbKhzT6+BWZF0t87ln5t4W7WpKqrenyPFtreCmtSkjMBT0IsZ1hTIDGZwlsbvD4Owxa4FdAIGi5vWldM6Ffm1/R5RFrLNpVECDnGUIfQhggjIcu9/4W/fSueTwLNaiwG+CmLFqoXrfjut1EplX+N2NTcLobGKCqztr5PcgplrcDWaZI7mRKAZCIB3z9xEjLNZz7FVVIgodi+A3/Ih3z4or2C1n5KIaAhmCgvoDdzLY4mqofd53uxc3QxNVnZbcg62J6kr4XzVxjdPGmaw0WJDWO3iCfdUZwXMSwXBUdTXXAymsE/AxpvyN+rTrPGxO2NuYYQqSOLC9PlWZU2jzmbCDPT0shrOQvNMSlKZ/D13nuWdWhKPAka/yKq/tZErc8nLEa2EwcHesu4Z8RAFymNnuv//e+HsVQLxOoO82zXwKCS0zM9HA7L5xiP94EPEcT6qHFCo8HclfAJKVrCZLe1DE1IejEryIEIrVQzuzeoBwR9Dbf8v2KHT0S00O6d55l+C7m0HaPNS+UqYEljj3UR2avgt101ILzTG2ILhsBHGsD9lz0Tep0XhEdc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 install:
   - pip install .
-  - pip install docutils  # Used to check package metadata.
+  - pip install docutils pygments  # Used to check package metadata.
 
 script:
   - python setup.py check --strict --metadata --restructuredtext

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ For more advanced usage, check out the documentation on `ReadTheDocs`_!
 Requirements
 ------------
 
-ClassRegistry is compatible with Python versions 3.6, 3.5 and 2.7.
+ClassRegistry is compatible with Python versions 3.7, 3.6, 3.5 and 2.7.
 
 
 Installation
@@ -97,11 +97,20 @@ To run the unit tests, it is recommended that you use the `detox`_ library.
 detox speeds up the tests by running them in parallel.
 
 Install the package with the ``test-runner`` extra to set up the necessary
-dependencies, and then you can run the tests with the ``detox`` command::
+dependencies, and then you can run the tests with the ``tox`` command::
 
   pip install -e .[test-runner]
-  detox -v
+  tox
 
+.. tip::
+  To run tests for multiple Python versions in parallel::
+
+    # Python 3.7 only
+    tox -p all
+
+    # Python 3.6 or earlier
+    pip install detox
+    detox
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,7 @@
 .. image:: https://readthedocs.org/projects/class-registry/badge/?version=latest
    :target: http://class-registry.readthedocs.io/
 
+
 =============
 ClassRegistry
 =============
@@ -17,7 +18,7 @@ At the intersection of the Registry and Factory patterns lies the
   infinitely extensible by 3rd-party libraries!
 - And more!
 
----------------
+
 Getting Started
 ---------------
 
@@ -53,8 +54,9 @@ To create a class instance from a registry, use the subscript operator:
    # How come my rival always picks the type that my pokémon is weak against??
    fighter2 = pokedex['grass']
 
+
 Advanced Usage
---------------
+~~~~~~~~~~~~~~
 
 There's a whole lot more you can do with ClassRegistry, including:
 
@@ -65,15 +67,15 @@ There's a whole lot more you can do with ClassRegistry, including:
 - Wrap your registry in an instance cache to create a service registry.
 - And more!
 
-For more advanced usage, `check out the documentation on RTD`_!
+For more advanced usage, check out the documentation on `ReadTheDocs`_!
 
-------------
+
 Requirements
 ------------
 
 ClassRegistry is compatible with Python versions 3.6, 3.5 and 2.7.
 
-------------
+
 Installation
 ------------
 
@@ -82,5 +84,45 @@ Install the latest stable version via pip::
    pip install class-registry
 
 
+Running Unit Tests
+------------------
+To run unit tests after installing from source::
 
-.. _check out the documentation on rtd: https://class-registry.readthedocs.org/
+  python setup.py test
+
+This project is also compatible with `tox`_, which will run the unit tests in
+different virtual environments (one for each supported version of Python).
+
+To run the unit tests, it is recommended that you use the `detox`_ library.
+detox speeds up the tests by running them in parallel.
+
+Install the package with the ``test-runner`` extra to set up the necessary
+dependencies, and then you can run the tests with the ``detox`` command::
+
+  pip install -e .[test-runner]
+  detox -v
+
+
+Documentation
+-------------
+Documentation is available on `ReadTheDocs`_.
+
+If you are installing from source (see above), you can also build the
+documentation locally:
+
+#. Install extra dependencies (you only have to do this once)::
+
+      pip install '.[docs-builder]'
+
+#. Switch to the ``docs`` directory::
+
+      cd docs
+
+#. Build the documentation::
+
+      make html
+
+
+.. _ReadTheDocs: https://class-registry.readthedocs.io/
+.. _detox: https://pypi.python.org/pypi/detox
+.. _tox: https://tox.readthedocs.io/

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from functools import cmp_to_key
 from inspect import isclass as is_class
 from typing import Any, Callable, Generator, Hashable, Iterator, \
-    Mapping, MutableMapping, Optional, Text, Tuple, Union
+    Optional, Text, Tuple, Union
 
 from six import PY2, iteritems, with_metaclass
 
@@ -30,7 +30,13 @@ class RegistryKeyError(KeyError):
     pass
 
 
-class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
+# This class "should" also derive from Mapping, but this causes a
+# conflict in Python 3.7 because ``with_metaclass()`` creates a type
+# dynamically.
+#
+# See https://bugs.python.org/issue33188 for more information.
+# https://github.com/eflglobal/class-registry/issues/9
+class BaseRegistry(with_metaclass(ABCMeta)):
     """
     Base functionality for registries.
     """
@@ -207,7 +213,13 @@ class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
             return self.values()
 
 
-class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry, MutableMapping)):
+# This class "should" also derive from MutableMapping, but this causes a
+# conflict in Python 3.7 because ``with_metaclass()`` creates a type
+# dynamically.
+#
+# See https://bugs.python.org/issue33188 for more information.
+# https://github.com/eflglobal/class-registry/issues/9
+class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry)):
     """
     Extends :py:class:`BaseRegistry` with methods that can be used to
     modify the registered classes.

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -6,10 +6,10 @@ from abc import ABCMeta, abstractmethod as abstract_method
 from collections import OrderedDict
 from functools import cmp_to_key
 from inspect import isclass as is_class
-from typing import Any, Callable, Generator, Hashable, Iterator, \
-    Optional, Text, Tuple, Union
+from typing import Any, Callable, Generator, Hashable, Iterator, Mapping, \
+    MutableMapping, Optional, Text, Tuple, Union
 
-from six import PY2, iteritems, with_metaclass
+from six import PY2, add_metaclass, iteritems
 
 __all__ = [
     'BaseRegistry',
@@ -30,13 +30,9 @@ class RegistryKeyError(KeyError):
     pass
 
 
-# This class "should" also derive from Mapping, but this causes a
-# conflict in Python 3.7 because ``with_metaclass()`` creates a type
-# dynamically.
-#
-# See https://bugs.python.org/issue33188 for more information.
 # https://github.com/eflglobal/class-registry/issues/9
-class BaseRegistry(with_metaclass(ABCMeta)):
+@add_metaclass(ABCMeta)
+class BaseRegistry(Mapping):
     """
     Base functionality for registries.
     """
@@ -213,13 +209,9 @@ class BaseRegistry(with_metaclass(ABCMeta)):
             return self.values()
 
 
-# This class "should" also derive from MutableMapping, but this causes a
-# conflict in Python 3.7 because ``with_metaclass()`` creates a type
-# dynamically.
-#
-# See https://bugs.python.org/issue33188 for more information.
 # https://github.com/eflglobal/class-registry/issues/9
-class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry)):
+@add_metaclass(ABCMeta)
+class MutableRegistry(BaseRegistry, MutableMapping):
     """
     Extends :py:class:`BaseRegistry` with methods that can be used to
     modify the registered classes.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = 'Factory+Registry pattern for Python classes.',
     url = 'https://class-registry.readthedocs.io/',
 
-    version = '2.1.2',
+    version = '2.1.3',
 
     packages = ['class_registry'],
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
 
     extras_require = {
         'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
-        'test-runner': ['detox'],
+        'test-runner': ['tox'],
     },
 
     test_suite    = 'test',
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description = long_description,
 
     install_requires = [
-        'six',
+        'six >= 1.4.0',
         'typing; python_version < "3.0"',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ setup(
         'typing; python_version < "3.0"',
     ],
 
+    extras_require = {
+        'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
+        'test-runner': ['detox'],
+    },
+
     test_suite    = 'test',
     test_loader   = 'nose.loader:TestLoader',
     tests_require = ['nose'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
* Added support for Python 3.7 (thanks @henriklynggaard for reporting and @stj for fixing!).
* Updated documentation for unit tests; `detox` is deprecated in favour of `tox -p all` in Python 3.7.