### PR TITLE
ClassRegistry v3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,26 @@
-dist: xenial
 language: python
 python:
-  - '2.7'
   - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8-dev'
+  - 'pypy3'
 
 install:
   - pip install .
-  - pip install docutils pygments  # Used to check package metadata.
+  - pip install docutils pygments
 
 script:
   - python setup.py check --strict --metadata --restructuredtext
   - python setup.py test
 
 deploy:
-  - on:
-      python: '3.7'
-      tags: true
-    provider: pypi
-    distributions: 'bdist_wheel sdist'
-    user: efl_phx
-    password:
-      secure: XE0fhr1GgWTUgV9ssVYJkO+V9AehYJy2kf5T9T7YB1SQMLOeqr0QcpUEbKYgObxVuAu6gXd0WbUYSMcayblrWQdVwZ9f8/wadU9JPT+3QNTy7/S/hcExbKhzT6+BWZF0t87ln5t4W7WpKqrenyPFtreCmtSkjMBT0IsZ1hTIDGZwlsbvD4Owxa4FdAIGi5vWldM6Ffm1/R5RFrLNpVECDnGUIfQhggjIcu9/4W/fSueTwLNaiwG+CmLFqoXrfjut1EplX+N2NTcLobGKCqztr5PcgplrcDWaZI7mRKAZCIB3z9xEjLNZz7FVVIgodi+A3/Ih3z4or2C1n5KIaAhmCgvoDdzLY4mqofd53uxc3QxNVnZbcg62J6kr4XzVxjdPGmaw0WJDWO3iCfdUZwXMSwXBUdTXXAymsE/AxpvyN+rTrPGxO2NuYYQqSOLC9PlWZU2jzmbCDPT0shrOQvNMSlKZ/D13nuWdWhKPAka/yKq/tZErc8nLEa2EwcHesu4Z8RAFymNnuv//e+HsVQLxOoO82zXwKCS0zM9HA7L5xiP94EPEcT6qHFCo8HclfAJKVrCZLe1DE1IejEryIEIrVQzuzeoBwR9Dbf8v2KHT0S00O6d55l+C7m0HaPNS+UqYEljj3UR2avgt101ILzTG2ILhsBHGsD9lz0Tep0XhEdc=
+  matrix:
+    - true:
+        python: '3.7'
+        tags: true
+      provider: pypi
+      distributions: bdist_wheel sdist
+      user: phx
+      password:
+        secure: h7C7gj7bTzqJzilbrePGKJlkQkH4FqXkdd/h5P6Uny94jojbzhjp/Qdz9Mz355t4q07v/XtLiw6DoERvlTueRx1qdfyMAR3xwxFVQ5Xx2+58pJhnsSMIJqalia+2UOE/T88vwxpnebAUP39CzLP0N5E4rZN5t7+9mcj0Yi11VY1hfUQZwYfsoFQaZlQgq0FV3F+ZKQ3W2XFE3mZ0ZFs3n3Wrjr0EgJMUhZ/MjtX76V7di1y6VaY0MeoUffD9n4Be0C6CdkiLEUdlqaNA9eEPkpcqqGixroPtstnDtbvEfDf+TR1pjzdZIjVQebc++jkxGkcsJH8/doEAig3lqE/jgj3MMy+2YNtUQxvO6Hlo7AhDCAGQzKCHntJiJWjsFP5Bwt50gchbVFIASlojH/vU67SZSXj/ZgcllNduwb+DgvNex0TdBCUw7x5E3lltbnjjKdNCWj0Omv8c6svp4RHLHkRmJRh9Y0Q+wXMYIoHwo2+N2pxOpy3bGk5QECxAzgj2JEGMWBO2WYr0kFFUTL9THsIrt4l3E3GcHX7+dBRN9Lsfuot+q+4HjvuBseCxq7DUHfwTkroPIkakkmaxIScX/pvuL7S8u6zkh2PkKieSCHBZOKAc8DFi+WddBFgmWI1/y44UoE6yUcZvxnW6fQUwWtU8nwmYm/65DCIDSct6y1M=

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ ClassRegistry is compatible with the following Python versions:
 - 3.6
 - 3.5
 
+pypy3 is also supported.
+
 .. note::
   ClassRegistry is **not** compatible with Python 2.
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/eflglobal/class-registry.svg?branch=master
-   :target: https://travis-ci.org/eflglobal/class-registry
+.. image:: https://travis-ci.org/todofixthis/class-registry.svg?branch=master
+   :target: https://travis-ci.org/todofixthis/class-registry
 .. image:: https://readthedocs.org/projects/class-registry/badge/?version=latest
    :target: http://class-registry.readthedocs.io/
 
@@ -125,6 +125,6 @@ documentation locally:
       make html
 
 
-.. _ReadTheDocs: https://todofixthis-class-registry.readthedocs.io/
+.. _ReadTheDocs: https://class-registry.readthedocs.io/
 .. _detox: https://pypi.python.org/pypi/detox
 .. _tox: https://tox.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,9 @@
 .. image:: https://readthedocs.org/projects/class-registry/badge/?version=latest
    :target: http://class-registry.readthedocs.io/
 
-
 =============
 ClassRegistry
 =============
-
 At the intersection of the Registry and Factory patterns lies the
 ``ClassRegistry``:
 
@@ -21,7 +19,6 @@ At the intersection of the Registry and Factory patterns lies the
 
 Getting Started
 ---------------
-
 Create a registry using the ``class_registry.ClassRegistry`` class, then
 decorate any classes that you wish to register with its ``register`` method:
 
@@ -57,7 +54,6 @@ To create a class instance from a registry, use the subscript operator:
 
 Advanced Usage
 ~~~~~~~~~~~~~~
-
 There's a whole lot more you can do with ClassRegistry, including:
 
 - Provide args and kwargs to new class instances.
@@ -72,13 +68,18 @@ For more advanced usage, check out the documentation on `ReadTheDocs`_!
 
 Requirements
 ------------
+ClassRegistry is compatible with the following Python versions:
 
-ClassRegistry is compatible with Python versions 3.7, 3.6, 3.5 and 2.7.
+- 3.8
+- 3.7
+- 3.6
+- 3.5
 
+.. note::
+  ClassRegistry is **not** compatible with Python 2.
 
 Installation
 ------------
-
 Install the latest stable version via pip::
 
    pip install class-registry
@@ -97,20 +98,10 @@ To run the unit tests, it is recommended that you use the `detox`_ library.
 detox speeds up the tests by running them in parallel.
 
 Install the package with the ``test-runner`` extra to set up the necessary
-dependencies, and then you can run the tests with the ``tox`` command::
+dependencies, and then you can run the tests with the ``detox`` command::
 
   pip install -e .[test-runner]
-  tox
-
-.. tip::
-  To run tests for multiple Python versions in parallel::
-
-    # Python 3.7 only
-    tox -p all
-
-    # Python 3.6 or earlier
-    pip install detox
-    detox
+  detox
 
 Documentation
 -------------
@@ -132,6 +123,6 @@ documentation locally:
       make html
 
 
-.. _ReadTheDocs: https://class-registry.readthedocs.io/
+.. _ReadTheDocs: https://todofixthis-class-registry.readthedocs.io/
 .. _detox: https://pypi.python.org/pypi/detox
 .. _tox: https://tox.readthedocs.io/

--- a/class_registry/__init__.py
+++ b/class_registry/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .registry import *
 from .auto_register import *
 from .cache import *

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta
 from inspect import isabstract as is_abstract
 
@@ -12,8 +8,7 @@ __all__ = [
 ]
 
 
-def AutoRegister(registry, base_type=ABCMeta):
-    # type: (MutableRegistry, type) -> type
+def AutoRegister(registry: MutableRegistry, base_type: type = ABCMeta) -> type:
     """
     Creates a metaclass that automatically registers all non-abstract
     subclasses in the specified registry.

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -1,11 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+import typing
 from collections import defaultdict
-from typing import Any, Dict, Generator, Hashable
-
-from six import iterkeys
 
 from class_registry import ClassRegistry
 
@@ -27,8 +21,8 @@ class ClassRegistryInstanceCache(object):
     any classes that are registered afterward are accessible to
     both the ClassRegistry and the ClassRegistryInstanceCache.
     """
-    def __init__(self, class_registry, *args, **kwargs):
-        # type: (ClassRegistry, *Any, **Any) -> None
+
+    def __init__(self, class_registry: ClassRegistry, *args, **kwargs) -> None:
         """
         :param class_registry:
             The wrapped ClassRegistry.
@@ -43,13 +37,15 @@ class ClassRegistryInstanceCache(object):
         """
         super(ClassRegistryInstanceCache, self).__init__()
 
-        self._registry  = class_registry
-        self._cache     = {}
+        self._registry = class_registry
+        self._cache = {}
 
-        self._key_map = defaultdict(list) # type: Dict[Hashable, list]
+        self._key_map = defaultdict(
+            list,
+        )  # type: typing.Dict[typing.Hashable, list]
 
-        self._template_args     = args
-        self._template_kwargs   = kwargs
+        self._template_args = args
+        self._template_kwargs = kwargs
 
     def __getitem__(self, key):
         """
@@ -65,7 +61,7 @@ class ClassRegistryInstanceCache(object):
             # :py:meth:`__iter__`
             self._key_map[class_key].append(instance_key)
 
-            self._cache[instance_key] =\
+            self._cache[instance_key] = \
                 self._registry.get(
                     class_key,
                     *self._template_args,
@@ -74,15 +70,14 @@ class ClassRegistryInstanceCache(object):
 
         return self._cache[instance_key]
 
-    def __iter__(self):
-        # type: () -> Generator[Any]
+    def __iter__(self) -> typing.Generator[typing.Any, None, None]:
         """
         Returns a generator for iterating over cached instances, using
         the wrapped registry to determine sort order.
 
         If a key has not been accessed yet, it will not be included.
         """
-        for lookup_key in iterkeys(self._registry):
+        for lookup_key in self._registry.keys():
             for cache_key in self._key_map[lookup_key]:
                 yield self._cache[cache_key]
 
@@ -94,11 +89,10 @@ class ClassRegistryInstanceCache(object):
         Note that this method does not account for any classes that may
         be added to the wrapped ClassRegistry in the future.
         """
-        for key in iterkeys(self._registry):
+        for key in self._registry.keys():
             self.__getitem__(key)
 
-    def get_instance_key(self, key):
-        # type: (Any) -> Hashable
+    def get_instance_key(self, key: typing.Any) -> typing.Hashable:
         """
         Generates a key that can be used to store/lookup values in the
         instance cache.
@@ -108,8 +102,7 @@ class ClassRegistryInstanceCache(object):
         """
         return self.get_class_key(key)
 
-    def get_class_key(self, key):
-        # type: (Any) -> Hashable
+    def get_class_key(self, key: typing.Any) -> typing.Hashable:
         """
         Generates a key that can be used to store/lookup values in the
         wrapped :py:class:`ClassRegistry` instance.

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -1,11 +1,6 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-from typing import Dict, Optional, Text
+import typing
 
 from pkg_resources import iter_entry_points
-from six import iteritems
 
 from class_registry import BaseRegistry
 
@@ -18,8 +13,12 @@ class EntryPointClassRegistry(BaseRegistry):
     """
     A class registry that loads classes using setuptools entry points.
     """
-    def __init__(self, group, attr_name=None):
-        # type: (Text, Optional[Text]) -> None
+
+    def __init__(
+            self,
+            group: str,
+            attr_name: typing.Optional[str] = None,
+    ) -> None:
         """
         :param group:
             The name of the entry point group that will be used to load
@@ -35,10 +34,10 @@ class EntryPointClassRegistry(BaseRegistry):
         """
         super(EntryPointClassRegistry, self).__init__()
 
-        self.attr_name  = attr_name
-        self.group      = group
+        self.attr_name = attr_name
+        self.group = group
 
-        self._cache = None # type: Optional[Dict[Text, type]]
+        self._cache = None  # type: typing.Optional[typing.Dict[str, type]]
         """
         Caches registered classes locally, so that we don't have to
         keep iterating over entry points.
@@ -54,12 +53,12 @@ class EntryPointClassRegistry(BaseRegistry):
 
     def __repr__(self):
         return '{type}(group={group!r})'.format(
-            group   = self.group,
-            type    = type(self).__name__,
+            group=self.group,
+            type=type(self).__name__,
         )
 
     def get(self, key, *args, **kwargs):
-        instance =\
+        instance = \
             super(EntryPointClassRegistry, self).get(key, *args, **kwargs)
 
         if self.attr_name:
@@ -79,7 +78,7 @@ class EntryPointClassRegistry(BaseRegistry):
         return cls
 
     def items(self):
-        return iteritems(self._get_cache())
+        return self._get_cache().items()
 
     def refresh(self):
         """
@@ -91,8 +90,7 @@ class EntryPointClassRegistry(BaseRegistry):
         """
         self._cache = None
 
-    def _get_cache(self):
-        # type: () -> Dict[Text, type]
+    def _get_cache(self) -> typing.Dict[str, type]:
         """
         Populates the cache (if necessary) and returns it.
         """
@@ -109,5 +107,4 @@ class EntryPointClassRegistry(BaseRegistry):
 
                 self._cache[e.name] = cls
 
-        # noinspection PyTypeChecker
         return self._cache

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -1,11 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-from typing import Any
-
-from six import iteritems
-
 from class_registry.registry import MutableRegistry, RegistryKeyError
 
 __all__ = [
@@ -20,14 +12,14 @@ class RegistryPatcher(object):
 
     Note: only mutable registries can be patched!
     """
+
     class DoesNotExist(object):
         """
         Used to identify a value that did not exist before we started.
         """
         pass
 
-    def __init__(self, registry, *args, **kwargs):
-        # type: (MutableRegistry, *Any, **Any) -> None
+    def __init__(self, registry: MutableRegistry, *args, **kwargs) -> None:
         """
         :param registry:
             A :py:class:`MutableRegistry` instance to patch.
@@ -54,13 +46,12 @@ class RegistryPatcher(object):
 
         self.target = registry
 
-        self._new_values  = kwargs
+        self._new_values = kwargs
         self._prev_values = {}
 
     def __enter__(self):
         self.apply()
 
-    # noinspection PyUnusedLocal
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.restore()
 
@@ -71,11 +62,11 @@ class RegistryPatcher(object):
         # Back up previous values.
         self._prev_values = {
             key: self._get_value(key, self.DoesNotExist)
-                for key in self._new_values
+            for key in self._new_values
         }
 
         # Patch values.
-        for key, value in iteritems(self._new_values):
+        for key, value in self._new_values.items():
             # Remove the existing value first (prevents issues if the
             # registry has ``unique=True``).
             self._del_value(key)
@@ -88,7 +79,7 @@ class RegistryPatcher(object):
         Restores previous settings.
         """
         # Restore previous settings.
-        for key, value in iteritems(self._prev_values):
+        for key, value in self._prev_values.items():
             # Remove the existing value first (prevents issues if the
             # registry has ``unique=True``).
             self._del_value(key)

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -1,9 +1,7 @@
-===============
 Advanced Topics
 ===============
 This section covers more advanced or esoteric uses of ClassRegistry features.
 
----------------------------------
 Registering Classes Automatically
 ---------------------------------
 Tired of having to add the ``register`` decorator to every class that you want
@@ -19,12 +17,11 @@ Here's an example:
 
    from abc import abstractmethod
    from class_registry import AutoRegister, ClassRegistry
-   from six import with_metaclass
 
    pokedex = ClassRegistry('element')
 
    # Note ``AutoRegister(pokedex)`` used as the metaclass here.
-   class Pokemon(with_metaclass(AutoRegister(pokedex))):
+   class Pokemon(metaclass=AutoRegister(pokedex)):
       @abstractmethod
       def get_abilities(self):
         raise NotImplementedError()
@@ -61,7 +58,7 @@ because it is abstract.
       from abc import ABCMeta
 
       # Declare an "abstract" class.
-      class ElectricPokemon(with_metaclass(ABCMeta, Pokemon)):
+      class ElectricPokemon(Pokemon, metaclass=ABCMeta):
         element = 'electric'
 
         def get_abilities(self):
@@ -85,7 +82,7 @@ because it is abstract.
       from inspect import isabstract
       assert not isabstract(ElectricPokemon)
 
---------
+
 Patching
 --------
 From time to time, you might need to register classes temporarily.  For example,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
 # class-registry documentation build configuration file, created by
 # sphinx-quickstart on Wed Jun 28 17:10:35 2017.
 #

--- a/docs/entry_points.rst
+++ b/docs/entry_points.rst
@@ -1,4 +1,3 @@
-========================
 Entry Points Integration
 ========================
 A serially-underused feature of setuptools is its `entry points`_.  This feature
@@ -50,7 +49,6 @@ Simply declare an :py:class:`EntryPointClassRegistry` instance, and it will
 automatically find any classes registered to that entry point group across every
 single installed project in your virtualenv!
 
----------------
 Reverse Lookups
 ---------------
 From time to time, you may need to perform a "reverse lookup":  Given a class or

--- a/docs/factories_vs_registries.rst
+++ b/docs/factories_vs_registries.rst
@@ -1,4 +1,3 @@
-========================
 Factories vs. Registries
 ========================
 Despite its name, :py:class:`ClassRegistry` also has aspects in common with the

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,7 +1,5 @@
-===============
 Getting Started
 ===============
-
 As you saw in the :doc:`introduction </index>`, you can create a new registry
 using the :py:class:`class_registry.ClassRegistry` class.
 
@@ -40,10 +38,9 @@ raise a :py:class:`class_registry.RegistryKeyError`:
    except RegistryKeyError:
      pass
 
--------------
+
 Registry Keys
 -------------
-
 By default, you have to provide the registry key whenever you register a new
 class.  But, there's an easier way to do it!
 
@@ -65,7 +62,6 @@ extract the registry key using that attribute:
 Note in the above example that the registry automatically extracted the registry
 key for the ``Squirtle`` class using its ``element`` attribute.
 
-----------
 Collisions
 ----------
 What happens if two classes have the same registry key?
@@ -120,7 +116,6 @@ occurs:
 Attempting to register ``Ivysaur`` with the same registry key as ``Bulbasaur``
 raised a :py:class:`RegistryKeyError`, so it didn't override ``Bulbasaur``.
 
------------
 Init Params
 -----------
 Every time you access a registry key in a :py:class:`ClassRegistry`, it creates

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,5 @@
 ClassRegistry
 =============
-
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
@@ -12,10 +11,8 @@ ClassRegistry
    advanced_topics
 
 
-=============
 ClassRegistry
 =============
-
 At the intersection of the Registry and Factory patterns lies the
 ``ClassRegistry``:
 
@@ -26,10 +23,8 @@ At the intersection of the Registry and Factory patterns lies the
   infinitely extensible by 3rd-party libraries!
 - And more!
 
----------------
 Getting Started
 ---------------
-
 Create a registry using the ``class_registry.ClassRegistry`` class, then
 decorate any classes that you wish to register with its ``register`` method:
 
@@ -64,7 +59,6 @@ To create a class instance from a registry, use the subscript operator:
 
 Advanced Usage
 --------------
-
 There's a whole lot more you can do with ClassRegistry, including:
 
 - Provide args and kwargs to new class instances.
@@ -77,16 +71,20 @@ There's a whole lot more you can do with ClassRegistry, including:
 To learn more about what you can do with ClassRegistry,
 :doc:`keep reading! </getting_started>`
 
-------------
 Requirements
 ------------
+ClassRegistry is compatible with the following Python versions:
 
-ClassRegistry is compatible with Python versions 3.6, 3.5 and 2.7.
+- 3.8
+- 3.7
+- 3.6
+- 3.5
 
-------------
+.. note::
+  ClassRegistry is **not** compatible with Python 2.
+
 Installation
 ------------
-
 Install the latest stable version via pip::
 
    pip install class-registry

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,8 @@ ClassRegistry is compatible with the following Python versions:
 - 3.6
 - 3.5
 
+pypy3 is also supported.
+
 .. note::
   ClassRegistry is **not** compatible with Python 2.
 

--- a/docs/iterating_over_registries.rst
+++ b/docs/iterating_over_registries.rst
@@ -1,4 +1,3 @@
-=========================
 Iterating Over Registries
 =========================
 Sometimes, you want to iterate over all of the classes registered in a
@@ -50,7 +49,6 @@ Here's an example:
    all non-abstract subclasses of a particular base class.  See
    :doc:`advanced_topics` for more information.
 
------------------------
 Changing the Sort Order
 -----------------------
 As you probably noticed, these functions iterate over classes in the order that

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,3 @@
-# coding=utf-8
-# Not importing unicode_literals because in Python 2 distutils, some
-# values are expected to be byte strings.
-from __future__ import absolute_import, division, print_function
-
 from codecs import StreamReader, open
 from os.path import dirname, join, realpath
 
@@ -12,45 +7,39 @@ cwd = dirname(realpath(__file__))
 
 ##
 # Load long description for PyPi.
-with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f: # type: StreamReader
+with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f:  # type: StreamReader
     long_description = f.read()
-
 
 ##
 # Off we go!
 setup(
-    name = 'class-registry',
-    description = 'Factory+Registry pattern for Python classes.',
-    url = 'https://class-registry.readthedocs.io/',
+    name='class-registry',
+    description='Factory+Registry pattern for Python classes.',
+    url='https://class-registry.readthedocs.io/',
 
-    version = '2.1.3',
+    version='3.0.0',
 
-    packages = ['class_registry'],
+    packages=['class_registry'],
 
-    long_description = long_description,
+    long_description=long_description,
 
-    install_requires = [
-        'six >= 1.4.0',
-        'typing; python_version < "3.0"',
-    ],
+    install_requires=[],
 
-    extras_require = {
+    extras_require={
         'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
-        'test-runner': ['tox'],
+        'test-runner':  ['detox'],
     },
 
-    test_suite    = 'test',
-    test_loader   = 'nose.loader:TestLoader',
-    tests_require = ['nose'],
+    test_suite='test',
+    test_loader='nose.loader:TestLoader',
+    tests_require=['nose'],
 
-    license = 'MIT',
+    license='MIT',
 
-    classifiers = [
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -58,8 +47,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 
-    keywords = 'registry pattern',
+    keywords='registry pattern',
 
-    author          = 'Phoenix Zerin',
-    author_email    = 'phoenix.zerin@eflglobal.com',
+    author='Phoenix Zerin',
+    author_email='phx@phx.ph',
 )

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f:  # type: StreamReader
 ##
 # Off we go!
 setup(
-    name='class-registry',
+    name='todofixthis-class-registry',
     description='Factory+Registry pattern for Python classes.',
-    url='https://class-registry.readthedocs.io/',
+    url='https://todofixthis-class-registry.readthedocs.io/',
 
     version='3.0.0',
 
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f:  # type: StreamReader
 setup(
     name='todofixthis-class-registry',
     description='Factory+Registry pattern for Python classes.',
-    url='https://todofixthis-class-registry.readthedocs.io/',
+    url='https://class-registry.readthedocs.io/',
 
     version='3.0.0',
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,8 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-
 class Pokemon(object):
     """
     A basic class with some attributes that we can use to test out
@@ -17,13 +12,32 @@ class Pokemon(object):
 
 
 # Define some classes that we can register.
-class Charmander(Pokemon):  element = 'fire'
-class Charmeleon(Pokemon):  element = 'fire'
-class Squirtle(Pokemon):    element = 'water'
-class Wartortle(Pokemon):   element = 'water'
-class Bulbasaur(Pokemon):   element = 'grass'
-class Ivysaur(Pokemon):     element = 'grass'
-class Mew(Pokemon):         element = 'psychic'
+class Charmander(Pokemon):
+    element = 'fire'
+
+
+class Charmeleon(Pokemon):
+    element = 'fire'
+
+
+class Squirtle(Pokemon):
+    element = 'water'
+
+
+class Wartortle(Pokemon):
+    element = 'water'
+
+
+class Bulbasaur(Pokemon):
+    element = 'grass'
+
+
+class Ivysaur(Pokemon):
+    element = 'grass'
+
+
+class Mew(Pokemon):
+    element = 'psychic'
 
 
 class PokemonFactory(object):
@@ -31,6 +45,7 @@ class PokemonFactory(object):
     A factory that can produce new pokémon on demand.  Used to test how
     registries behave when a function is registered instead of a class.
     """
+
     @classmethod
     def create_psychic_pokemon(cls, name=None):
         return Mew(name)

--- a/test/auto_register_test.py
+++ b/test/auto_register_test.py
@@ -1,11 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta, abstractmethod as abstract_method
 from unittest import TestCase
-
-from six import with_metaclass
 
 from class_registry import AutoRegister, ClassRegistry
 
@@ -19,15 +13,15 @@ class AutoRegisterTestCase(TestCase):
 
         # Note that we declare :py:func:`AutoRegister` as the metaclass
         # for our base class.
-        class BasePokemon(with_metaclass(AutoRegister(registry))):
+        class BasePokemon(metaclass=AutoRegister(registry)):
             """
             Abstract base class; will not get registered.
             """
+
             @abstract_method
             def get_abilities(self):
                 raise NotImplementedError()
 
-        # noinspection PyClassHasNoInit
         class Sandslash(BasePokemon):
             """
             Non-abstract subclass; will get registered automatically.
@@ -37,16 +31,15 @@ class AutoRegisterTestCase(TestCase):
             def get_abilities(self):
                 return ['sand veil']
 
-        # noinspection PyClassHasNoInit
-        class BaseEvolvingPokemon(with_metaclass(ABCMeta, BasePokemon)):
+        class BaseEvolvingPokemon(BasePokemon, metaclass=ABCMeta):
             """
             Abstract subclass; will not get registered.
             """
+
             @abstract_method
             def evolve(self):
                 raise NotImplementedError()
 
-        # noinspection PyClassHasNoInit
         class Ekans(BaseEvolvingPokemon):
             """
             Non-abstract subclass; will get registered automatically.
@@ -58,7 +51,6 @@ class AutoRegisterTestCase(TestCase):
 
             def evolve(self):
                 return 'Congratulations! Your EKANS evolved into ARBOK!'
-
 
         self.assertListEqual(
             list(registry.items()),
@@ -77,7 +69,7 @@ class AutoRegisterTestCase(TestCase):
         """
         registry = ClassRegistry(attr_name='element')
 
-        class FightingPokemon(with_metaclass(AutoRegister(registry))):
+        class FightingPokemon(metaclass=AutoRegister(registry)):
             element = 'fighting'
 
         self.assertListEqual(

--- a/test/cache_test.py
+++ b/test/cache_test.py
@@ -1,11 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
-from class_registry.registry import ClassRegistry
 from class_registry.cache import ClassRegistryInstanceCache
+from class_registry.registry import ClassRegistry
 from test import Bulbasaur, Charmander, Charmeleon, Squirtle, Wartortle
 
 

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from os.path import dirname
 from unittest import TestCase
 

--- a/test/patcher_test.py
+++ b/test/patcher_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 from class_registry.patcher import RegistryPatcher

--- a/test/registry_test.py
+++ b/test/registry_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from functools import cmp_to_key
 from unittest import TestCase
 
@@ -153,7 +149,7 @@ class ClassRegistryTestCase(TestCase):
 
         # Goofus uses positional arguments, which are magical and
         # make his code more difficult to read.
-        goofus  = registry.get('grass', 'goofus')
+        goofus = registry.get('grass', 'goofus')
 
         # Gallant uses keyword arguments, producing self-documenting
         # code and being courteous to his fellow developers.
@@ -215,16 +211,16 @@ class SortedClassRegistryTestCase(TestCase):
         When iterating over a SortedClassRegistry, classes are returned
         in sorted order rather than inclusion order.
         """
-        registry =\
+        registry = \
             SortedClassRegistry(
-                attr_name   = 'element',
-                sort_key    = 'weight',
+                attr_name='element',
+                sort_key='weight',
             )
 
         @registry.register
         class Geodude(Pokemon):
             element = 'rock'
-            weight  = 100
+            weight = 100
 
         @registry.register
         class Machop(Pokemon):
@@ -247,17 +243,17 @@ class SortedClassRegistryTestCase(TestCase):
         """
         Reversing the order of a sort key.
         """
-        registry =\
+        registry = \
             SortedClassRegistry(
-                attr_name   = 'element',
-                sort_key    = 'weight',
-                reverse     = True,
+                attr_name='element',
+                sort_key='weight',
+                reverse=True,
             )
 
         @registry.register
         class Geodude(Pokemon):
             element = 'rock'
-            weight  = 100
+            weight = 100
 
         @registry.register
         class Machop(Pokemon):
@@ -281,17 +277,18 @@ class SortedClassRegistryTestCase(TestCase):
         If you want to use a ``cmp`` function to define the ordering,
         you must use the :py:func:`cmp_to_key` function.
         """
+
         def compare_pokemon(a, b):
             # ``a`` and ``b`` are tuples of ``(key, class)``.
             return (
                     (a[1].popularity < b[1].popularity)
-                -   (a[1].popularity > b[1].popularity)
+                    - (a[1].popularity > b[1].popularity)
             )
 
-        registry =\
+        registry = \
             SortedClassRegistry(
-                attr_name   = 'element',
-                sort_key    = cmp_to_key(compare_pokemon),
+                attr_name='element',
+                sort_key=cmp_to_key(compare_pokemon),
             )
 
         @registry.register

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py35, py36, py37, py38
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
- Dropped support for Python 2
- Added support for Python 3.7 and 3.8
- Added support for pypy3