### PR TITLE
Doc-string for unique flag confuses True and False

### DIFF
--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -299,8 +299,8 @@ class ClassRegistry(MutableRegistry):
             Determines what happens when two classes are registered with
             the same key:
 
-            - ``True``: The second class will replace the first one.
-            - ``False``: A ``ValueError`` will be raised.
+            - ``True``: A :py:class:`KeyError` will be raised.
+            - ``False``: The second class will replace the first one.
         """
         super(ClassRegistry, self).__init__(attr_name)
 


### PR DESCRIPTION
The documentation for `unique=False` is actually meant for  `unique=True` and vice versa.

Also, a [RegistryKeyError](https://github.com/todofixthis/class-registry/blob/a2ba0c95a4e9d3bb41c87abdd8f3453716289b87/class_registry/registry.py#L356), not a `ValueError`, is raised on collision if `unique=True`.