### PR TITLE
ClassRegistry v4.0.3

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-MIT License
+MIT Licence
 
 Copyright (c) 2017 EFL Global
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE
+include LICENCE.txt
 recursive-include test *.py

--- a/README.rst
+++ b/README.rst
@@ -106,15 +106,15 @@ documentation locally:
 
 #. Install extra dependencies (you only have to do this once)::
 
-   pip install -e '.[docs-builder]'
+    pip install -e '.[docs-builder]'
 
 #. Switch to the ``docs`` directory::
 
-   cd docs
+    cd docs
 
 #. Build the documentation::
 
-   make html
+    make html
 
 Releases
 --------
@@ -133,14 +133,17 @@ Build the Project
 #. The build artefacts will be located in the ``dist`` directory at the top
    level of the project.
 
-
 Upload to PyPI
 ~~~~~~~~~~~~~~
 #. `Create a PyPI API token`_ (you only have to do this once).
 #. Increment the version number in ``pyproject.toml``.
+#. Check that the build artefacts are valid, and fix any errors that it finds::
+
+    python -m twine check dist/*
+
 #. Upload build artefacts to PyPI::
 
-   python -m twine upload dist/*
+    python -m twine upload dist/*
 
 .. _Create a PyPI API token: https://pypi.org/manage/account/token/
 .. _Packaging Python Projects Tutorial: https://packaging.python.org/en/latest/tutorials/packaging-projects/

--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,8 @@ Install the latest stable version via pip::
 
 .. important::
    Make sure to install `phx-class-registry`, **not** `class-registry`.  I
-   created the latter in a previous job, but after I left they never touched
-   that project again — so in the end I had to fork it 🤷
+   created the latter at a previous job years ago, and after I left they never
+   touched that project again — so in the end I had to fork it 🤷
 
 Running Unit Tests
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ Upload to PyPI
 ~~~~~~~~~~~~~~
 #. `Create a PyPI API token`_ (you only have to do this once).
 #. Increment the version number in ``pyproject.toml``.
-#. Upload build artefacts to PyPI:
+#. Upload build artefacts to PyPI::
 
    python -m twine upload dist/*
 

--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,8 @@ Running Unit Tests
 Install the package with the ``test-runner`` extra to set up the necessary
 dependencies, and then you can run the tests with the ``tox`` command::
 
-  pip install -e .[test-runner]
-  tox -p all
+   pip install -e .[test-runner]
+   tox -p all
 
 Documentation
 -------------
@@ -106,16 +106,42 @@ documentation locally:
 
 #. Install extra dependencies (you only have to do this once)::
 
-      pip install '.[docs-builder]'
+   pip install -e '.[docs-builder]'
 
 #. Switch to the ``docs`` directory::
 
-      cd docs
+   cd docs
 
 #. Build the documentation::
 
-      make html
+   make html
+
+Releases
+--------
+Steps to build releases are based on `Packaging Python Projects Tutorial`_
+
+Build the Project
+~~~~~~~~~~~~~~~~~
+#. Install extra dependencies (you only have to do this once)::
+
+    pip install -e '.[build-system]'
+
+#. Run the build::
+
+    python -m build
+
+#. The build artefacts will be located in the ``dist`` directory at the top
+   level of the project.
 
 
+Upload to PyPI
+~~~~~~~~~~~~~~
+#. `Create a PyPI API token`_ (you only have to do this once).
+#. Upload build artefacts to PyPI:
+
+   python -m twine upload dist/*
+
+.. _Create a PyPI API token: https://pypi.org/manage/account/token/
+.. _Packaging Python Projects Tutorial: https://packaging.python.org/en/latest/tutorials/packaging-projects/
 .. _ReadTheDocs: https://class-registry.readthedocs.io/
 .. _tox: https://tox.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,10 @@ Steps to build releases are based on `Packaging Python Projects Tutorial`_
 
     pip install -e '.[build-system]'
 
+#. Delete artefacts from previous builds, if applicable::
+
+    rm dist/*
+
 #. Run the build::
 
     python -m build

--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,7 @@ Build the Project
 Upload to PyPI
 ~~~~~~~~~~~~~~
 #. `Create a PyPI API token`_ (you only have to do this once).
+#. Increment the version number in ``pyproject.toml``.
 #. Upload build artefacts to PyPI:
 
    python -m twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,6 @@ Steps to build releases are based on `Packaging Python Projects Tutorial`_
    Make sure to build releases off of the ``main`` branch, and check that all
    changes from ``develop`` have been merged before creating the release!
 
-.. _build-the-project:
-
 1. Build the Project
 ~~~~~~~~~~~~~~~~~~~~
 #. Install extra dependencies (you only have to do this once)::
@@ -172,8 +170,7 @@ Steps to build releases are based on `Packaging Python Projects Tutorial`_
    - Any backwards-incompatible changes and/or migration instructions.
    - SHA256 hashes of the build artefacts.
 #. GPG-sign the description for the release (ASCII-armoured).
-#. Attach the build artefacts created during
-   :ref:`1. Build the Project <build-the-project>`.
+#. Attach the build artefacts to the release.
 #. Click ``Publish release``.
 
 .. _Create a PyPI API token: https://pypi.org/manage/account/token/

--- a/README.rst
+++ b/README.rst
@@ -67,17 +67,15 @@ For more advanced usage, check out the documentation on `ReadTheDocs`_!
 
 Requirements
 ------------
-ClassRegistry is compatible with the following Python versions:
+ClassRegistry is known to be compatible with the following Python versions:
 
-- 3.8
-- 3.7
-- 3.6
-- 3.5
-
-pypy3 is also supported.
+- 3.11
+- 3.10
+- 3.9
 
 .. note::
-  ClassRegistry is **not** compatible with Python 2.
+   ClassRegistry's code is pretty simple, so it's likely to be compatible with
+   versions not listed here; there's just no test coverage to prove it 😇
 
 Installation
 ------------
@@ -86,15 +84,13 @@ Install the latest stable version via pip::
    pip install phx-class-registry
 
 
+.. important::
+   Make sure to install `phx-class-registry`, **not** `class-registry`.  I
+   created the latter in a previous job, but after I left they never touched
+   that project again — so in the end I had to fork it 🤷
+
 Running Unit Tests
 ------------------
-To run unit tests after installing from source::
-
-  python setup.py test
-
-This project is also compatible with `tox`_, which will run the unit tests in
-different virtual environments (one for each supported version of Python).
-
 Install the package with the ``test-runner`` extra to set up the necessary
 dependencies, and then you can run the tests with the ``tox`` command::
 

--- a/README.rst
+++ b/README.rst
@@ -120,8 +120,15 @@ Releases
 --------
 Steps to build releases are based on `Packaging Python Projects Tutorial`_
 
-Build the Project
-~~~~~~~~~~~~~~~~~
+.. important::
+
+   Make sure to build releases off of the ``main`` branch, and check that all
+   changes from ``develop`` have been merged before creating the release!
+
+.. _build-the-project:
+
+1. Build the Project
+~~~~~~~~~~~~~~~~~~~~
 #. Install extra dependencies (you only have to do this once)::
 
     pip install -e '.[build-system]'
@@ -133,8 +140,8 @@ Build the Project
 #. The build artefacts will be located in the ``dist`` directory at the top
    level of the project.
 
-Upload to PyPI
-~~~~~~~~~~~~~~
+2. Upload to PyPI
+~~~~~~~~~~~~~~~~~
 #. `Create a PyPI API token`_ (you only have to do this once).
 #. Increment the version number in ``pyproject.toml``.
 #. Check that the build artefacts are valid, and fix any errors that it finds::
@@ -145,7 +152,32 @@ Upload to PyPI
 
     python -m twine upload dist/*
 
+
+3. Create GitHub Release
+~~~~~~~~~~~~~~~~~~~~~~~~
+#. Create a tag and push to GitHub::
+
+    git tag <version>
+    git push
+
+   ``<version>`` must match the updated version number in ``pyproject.toml``.
+
+#. Go to the `Releases page for the repo`_.
+#. Click ``Draft a new release``.
+#. Select the tag that you created in step 1.
+#. Specify the title of the release (e.g., ``ClassRegistry v1.2.3``).
+#. Write a description for the release.  Make sure to include:
+   - Credit for code contributed by community members.
+   - Significant functionality that was added/changed/removed.
+   - Any backwards-incompatible changes and/or migration instructions.
+   - SHA256 hashes of the build artefacts.
+#. GPG-sign the description for the release (ASCII-armoured).
+#. Attach the build artefacts created during
+   :ref:`1. Build the Project <build-the-project>`.
+#. Click ``Publish release``.
+
 .. _Create a PyPI API token: https://pypi.org/manage/account/token/
 .. _Packaging Python Projects Tutorial: https://packaging.python.org/en/latest/tutorials/packaging-projects/
 .. _ReadTheDocs: https://class-registry.readthedocs.io/
+.. _Releases page for the repo: https://github.com/todofixthis/class-registry/releases
 .. _tox: https://tox.readthedocs.io/

--- a/class_registry/__init__.py
+++ b/class_registry/__init__.py
@@ -1,5 +1,5 @@
-from .registry import *
 from .auto_register import *
 from .cache import *
 from .entry_points import *
 from .patcher import *
+from .registry import *

--- a/class_registry/__init__.py
+++ b/class_registry/__init__.py
@@ -1,5 +1,5 @@
+from .registry import *
 from .auto_register import *
 from .cache import *
 from .entry_points import *
 from .patcher import *
-from .registry import *

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -1,14 +1,15 @@
 from abc import ABCMeta
 from inspect import isabstract as is_abstract
 
-from class_registry.registry import MutableRegistry
+from .registry import BaseMutableRegistry
 
 __all__ = [
     'AutoRegister',
 ]
 
 
-def AutoRegister(registry: MutableRegistry, base_type: type = ABCMeta) -> type:
+def AutoRegister(registry: BaseMutableRegistry,
+        base_type: type = ABCMeta) -> type:
     """
     Creates a metaclass that automatically registers all non-abstract
     subclasses in the specified registry.

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -13,16 +13,16 @@ def AutoRegister(registry: MutableRegistry, base_type: type = ABCMeta) -> type:
     Creates a metaclass that automatically registers all non-abstract
     subclasses in the specified registry.
 
-    IMPORTANT:  Python defines abstract as "having at least one
-    unimplemented abstract method"; specifying :py:class:`ABCMeta` as
-    the metaclass is not enough!
+    IMPORTANT:  Python defines abstract as "having at least one unimplemented
+    abstract method"; specifying :py:class:`ABCMeta` as the metaclass is not
+    enough!
 
     Example::
 
        commands = ClassRegistry(attr_name='command_name')
 
        # Specify ``AutoRegister`` as the metaclass:
-       class BaseCommand(with_metaclass(AutoRegister(commands))):
+       class BaseCommand(metaclass=AutoRegister(commands)):
          @abstractmethod
          def print(self):
            raise NotImplementedError()

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -10,16 +10,15 @@ __all__ = [
 
 class ClassRegistryInstanceCache(object):
     """
-    Wraps a ClassRegistry instance, caching instances as they are
-    created.
+    Wraps a ClassRegistry instance, caching instances as they are created.
 
-    This allows you to create [multiple] registries that cache
-    INSTANCES locally (so that they can be scoped and garbage-
-    collected), while keeping the CLASS registry separate.
+    This allows you to create [multiple] registries that cache INSTANCES
+    locally (so that they can be scoped and garbage-collected), while keeping
+    the CLASS registry separate.
 
-    Note that the internal class registry is copied by reference, so
-    any classes that are registered afterward are accessible to
-    both the ClassRegistry and the ClassRegistryInstanceCache.
+    Note that the internal class registry is copied by reference, so any
+    classes that are registered afterward are accessible to both the
+    ClassRegistry and the ClassRegistryInstanceCache.
     """
 
     def __init__(self, class_registry: ClassRegistry, *args, **kwargs) -> None:
@@ -28,21 +27,19 @@ class ClassRegistryInstanceCache(object):
             The wrapped ClassRegistry.
 
         :param args:
-            Positional arguments passed to the class registry's
-            template when creating new instances.
+            Positional arguments passed to the class registry's template when
+            creating new instances.
 
         :param kwargs:
-            Keyword arguments passed to the class registry's template
-            function when creating new instances.
+            Keyword arguments passed to the class registry's template function
+            when creating new instances.
         """
         super(ClassRegistryInstanceCache, self).__init__()
 
         self._registry = class_registry
-        self._cache = {}
+        self._cache: typing.Dict[typing.Hashable, type] = {}
 
-        self._key_map = defaultdict(
-            list,
-        )  # type: typing.Dict[typing.Hashable, list]
+        self._key_map: typing.Dict[typing.Hashable, list] = defaultdict(list)
 
         self._template_args = args
         self._template_kwargs = kwargs
@@ -56,24 +53,22 @@ class ClassRegistryInstanceCache(object):
         if instance_key not in self._cache:
             class_key = self.get_class_key(key)
 
-            # Map lookup keys to cache keys so that we can iterate over
-            # them in the correct order.
-            # :py:meth:`__iter__`
+            # Map lookup keys to cache keys so that we can iterate over them in
+            # the correct order.
             self._key_map[class_key].append(instance_key)
 
-            self._cache[instance_key] = \
-                self._registry.get(
-                    class_key,
-                    *self._template_args,
-                    **self._template_kwargs
-                )
+            self._cache[instance_key] = self._registry.get(
+                class_key,
+                *self._template_args,
+                **self._template_kwargs
+            )
 
         return self._cache[instance_key]
 
-    def __iter__(self) -> typing.Generator[typing.Any, None, None]:
+    def __iter__(self) -> typing.Generator[type, None, None]:
         """
-        Returns a generator for iterating over cached instances, using
-        the wrapped registry to determine sort order.
+        Returns a generator for iterating over cached instances, using the
+        wrapped registry to determine sort order.
 
         If a key has not been accessed yet, it will not be included.
         """
@@ -81,31 +76,32 @@ class ClassRegistryInstanceCache(object):
             for cache_key in self._key_map[lookup_key]:
                 yield self._cache[cache_key]
 
-    def warm_cache(self):
+    def warm_cache(self) -> None:
         """
-        Warms up the cache, ensuring that an instance is created for
-        every key in the registry.
+        Warms up the cache, ensuring that an instance is created for every key
+        currently in the registry.
 
-        Note that this method does not account for any classes that may
-        be added to the wrapped ClassRegistry in the future.
+        .. note::
+           This method does not account for any classes that may be added to
+           the wrapped ClassRegistry in the future.
         """
         for key in self._registry.keys():
             self.__getitem__(key)
 
-    def get_instance_key(self, key: typing.Any) -> typing.Hashable:
+    def get_instance_key(self, key: typing.Hashable) -> typing.Hashable:
         """
-        Generates a key that can be used to store/lookup values in the
-        instance cache.
+        Generates a key that can be used to store/lookup values in the instance
+        cache.
 
         :param key:
             Value provided to :py:meth:`__getitem__`.
         """
         return self.get_class_key(key)
 
-    def get_class_key(self, key: typing.Any) -> typing.Hashable:
+    def get_class_key(self, key: typing.Hashable) -> typing.Hashable:
         """
-        Generates a key that can be used to store/lookup values in the
-        wrapped :py:class:`ClassRegistry` instance.
+        Generates a key that can be used to store/lookup values in the wrapped
+        :py:class:`ClassRegistry` instance.
 
         This method is only invoked in the event of a cache miss.
 

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -1,7 +1,7 @@
 import typing
 from collections import defaultdict
 
-from class_registry import ClassRegistry
+from . import ClassRegistry
 
 __all__ = [
     'ClassRegistryInstanceCache',

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -2,7 +2,7 @@ import typing
 
 from pkg_resources import iter_entry_points
 
-from class_registry import BaseRegistry
+from . import BaseRegistry
 
 __all__ = [
     'EntryPointClassRegistry',
@@ -21,55 +21,55 @@ class EntryPointClassRegistry(BaseRegistry):
     ) -> None:
         """
         :param group:
-            The name of the entry point group that will be used to load
-            new classes.
+            The name of the entry point group that will be used to load new
+            classes.
 
         :param attr_name:
-            If set, the registry will "brand" each class with its
-            corresponding registry key.  This makes it easier to
-            perform reverse lookups later.
+            If set, the registry will "brand" each class with its corresponding
+            registry key.  This makes it easier to perform reverse lookups
+            later.
 
-            Note: if a class already defines this attribute, the
-            registry will overwrite it!
+            Note: if a class already defines this attribute, the registry will
+            overwrite it!
         """
         super(EntryPointClassRegistry, self).__init__()
 
         self.attr_name = attr_name
         self.group = group
 
-        self._cache = None  # type: typing.Optional[typing.Dict[str, type]]
+        self._cache: typing.Optional[typing.Dict[typing.Hashable, type]] = None
         """
-        Caches registered classes locally, so that we don't have to
-        keep iterating over entry points.
+        Caches registered classes locally, so that we don't have to keep
+        iterating over entry points.
         """
 
-        # If :py:attr:`attr_name` is set, warm the cache immediately to
-        # apply branding.
+        # If :py:attr:`attr_name` is set, warm the cache immediately, to apply
+        # branding.
         if self.attr_name:
             self._get_cache()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._get_cache())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{type}(group={group!r})'.format(
             group=self.group,
             type=type(self).__name__,
         )
 
-    def get(self, key, *args, **kwargs):
-        instance = \
-            super(EntryPointClassRegistry, self).get(key, *args, **kwargs)
+    def get(self, key: typing.Hashable, *args, **kwargs) -> object:
+        instance = super(EntryPointClassRegistry, self).get(key, *args,
+            **kwargs)
 
         if self.attr_name:
             # Apply branding to the instance explicitly.
-            # This is particularly important if the corresponding entry
-            # point references a function or method.
+            # This is particularly important if the corresponding entry point
+            # references a function or method.
             setattr(instance, self.attr_name, key)
 
         return instance
 
-    def get_class(self, key):
+    def get_class(self, key: typing.Hashable) -> typing.Optional[type]:
         try:
             cls = self._get_cache()[key]
         except KeyError:
@@ -77,20 +77,21 @@ class EntryPointClassRegistry(BaseRegistry):
 
         return cls
 
-    def items(self):
+    def items(self) -> typing.ItemsView[typing.Hashable, type]:
         return self._get_cache().items()
 
     def refresh(self):
         """
-        Purges the local cache.
-        The next access attempt will reload all entry points.
+        Purges the local cache.  The next access attempt will reload all entry
+        points.
 
-        This is useful if you load a distribution at runtime.
-        Otherwise, it probably serves no useful purpose.
+        This is useful if you load a distribution at runtime... such as during
+        unit tests for class-registry.  Otherwise, it probably serves no useful
+        purpose
         """
         self._cache = None
 
-    def _get_cache(self) -> typing.Dict[str, type]:
+    def _get_cache(self) -> typing.Dict[typing.Hashable, type]:
         """
         Populates the cache (if necessary) and returns it.
         """
@@ -99,9 +100,8 @@ class EntryPointClassRegistry(BaseRegistry):
             for e in iter_entry_points(self.group):
                 cls = e.load()
 
-                # Try to apply branding, but only for compatible types
-                # (i.e., functions and methods can't be branded this
-                # way).
+                # Try to apply branding, but only for compatible types (i.e.,
+                # functions and methods can't be branded this way).
                 if self.attr_name and isinstance(cls, type):
                     setattr(cls, self.attr_name, e.name)
 

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -1,4 +1,6 @@
-from class_registry.registry import MutableRegistry, RegistryKeyError
+import typing
+
+from .registry import MutableRegistry, RegistryKeyError
 
 __all__ = [
     'RegistryPatcher',
@@ -7,8 +9,8 @@ __all__ = [
 
 class RegistryPatcher(object):
     """
-    Creates a context in which classes are temporarily registered with
-    a class registry, then removed when the context exits.
+    Creates a context in which classes are temporarily registered with a class
+    registry, then removed when the context exits.
 
     Note: only mutable registries can be patched!
     """
@@ -33,11 +35,10 @@ class RegistryPatcher(object):
             Note: ``registry.attr_name`` must be set!
 
         :param kwargs:
-            Same as ``args``, except you explicitly specify the
-            registry keys.
+            Same as ``args``, except you explicitly specify the registry keys.
 
-            In the event of a conflict, values in ``args`` override
-            values in ``kwargs``.
+            In the event of a conflict, values in ``args`` override values in
+            ``kwargs``.
         """
         super(RegistryPatcher, self).__init__()
 
@@ -49,13 +50,13 @@ class RegistryPatcher(object):
         self._new_values = kwargs
         self._prev_values = {}
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.apply()
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.restore()
 
-    def apply(self):
+    def apply(self) -> None:
         """
         Applies the new values.
         """
@@ -67,36 +68,37 @@ class RegistryPatcher(object):
 
         # Patch values.
         for key, value in self._new_values.items():
-            # Remove the existing value first (prevents issues if the
-            # registry has ``unique=True``).
+            # Remove the existing value first (prevents issues if the registry
+            # has ``unique=True``).
             self._del_value(key)
 
             if value is not self.DoesNotExist:
                 self._set_value(key, value)
 
-    def restore(self):
+    def restore(self) -> None:
         """
         Restores previous settings.
         """
         # Restore previous settings.
         for key, value in self._prev_values.items():
-            # Remove the existing value first (prevents issues if the
-            # registry has ``unique=True``).
+            # Remove the existing value first (prevents issues if the registry
+            # has ``unique=True``).
             self._del_value(key)
 
             if value is not self.DoesNotExist:
                 self._set_value(key, value)
 
-    def _get_value(self, key, default=None):
+    def _get_value(self, key: typing.Hashable, default=None) -> \
+            typing.Optional[type]:
         try:
             return self.target.get_class(key)
         except RegistryKeyError:
             return default
 
-    def _set_value(self, key, value):
+    def _set_value(self, key: typing.Hashable, value: type) -> None:
         self.target.register(key)(value)
 
-    def _del_value(self, key):
+    def _del_value(self, key: typing.Hashable) -> None:
         try:
             self.target.unregister(key)
         except RegistryKeyError:

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -1,6 +1,6 @@
 import typing
 
-from .registry import MutableRegistry, RegistryKeyError
+from .registry import BaseMutableRegistry, RegistryKeyError
 
 __all__ = [
     'RegistryPatcher',
@@ -21,7 +21,7 @@ class RegistryPatcher(object):
         """
         pass
 
-    def __init__(self, registry: MutableRegistry, *args, **kwargs) -> None:
+    def __init__(self, registry: BaseMutableRegistry, *args, **kwargs) -> None:
         """
         :param registry:
             A :py:class:`MutableRegistry` instance to patch.

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -191,7 +191,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping,
         """
         Provides alternate syntax for un-registering a class.
         """
-        self._unregister(type(self).gen_lookup_key(key))
+        self._unregister(self.gen_lookup_key(key))
         del self._lookup_keys[key]
 
     def __repr__(self) -> str:
@@ -205,7 +205,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping,
         """
         Provides alternate syntax for registering a class.
         """
-        lookup_key = type(self).gen_lookup_key(key)
+        lookup_key = self.gen_lookup_key(key)
 
         self._register(lookup_key, class_)
         self._lookup_keys[key] = lookup_key
@@ -238,7 +238,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping,
         if is_class(key):
             if self.attr_name:
                 attr_key = getattr(key, self.attr_name)
-                lookup_key = type(self).gen_lookup_key(attr_key)
+                lookup_key = self.gen_lookup_key(attr_key)
 
                 # Note that ``getattr`` will raise an AttributeError if the
                 # class doesn't have the required attribute.
@@ -257,7 +257,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping,
 
         # ``@register('some_attr')`` usage:
         def _decorator(cls: type) -> type:
-            lookup_key = type(self).gen_lookup_key(key)
+            lookup_key = self.gen_lookup_key(key)
 
             self._register(lookup_key, cls)
             self._lookup_keys[key] = lookup_key
@@ -279,7 +279,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping,
         :raise:
             - :py:class:`KeyError` if the key is not registered.
         """
-        result = self._unregister(type(self).gen_lookup_key(key))
+        result = self._unregister(self.gen_lookup_key(key))
         del self._lookup_keys[key]
 
         return result
@@ -355,7 +355,7 @@ class ClassRegistry(BaseMutableRegistry):
         """
         Returns the class associated with the specified key.
         """
-        lookup_key = type(self).gen_lookup_key(key)
+        lookup_key = self.gen_lookup_key(key)
 
         try:
             return self._registry[lookup_key]
@@ -465,7 +465,7 @@ class SortedClassRegistry(ClassRegistry):
         typing.Tuple[typing.Hashable, type], None, None]:
         for (key, class_, _) in sorted(
                 # Provide human-readable key and lookup key to the sorter...
-                ((key, class_, type(self).gen_lookup_key(key)) for
+                ((key, class_, self.gen_lookup_key(key)) for
                         (key, class_) in super().items()),
                 key=self._sort_key,
                 reverse=self.reverse,

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -126,8 +126,8 @@ such a purpose:
    except RegistryKeyError:
      pass
 
-If desired, you can also change the registry key, or even replace a class that
-is already registered.
+If desired, you can also change existing registry keys, or even replace a class
+that is already registered.
 
 .. code-block:: python
 
@@ -148,7 +148,7 @@ is already registered.
 .. important::
 
    Only mutable registries can be patched (any class that extends
-   :py:class:`MutableRegistry`).
+   :py:class:`BaseMutableRegistry`).
 
    In particular, this means that :py:class:`EntryPointClassRegistry` can
    **not** be patched using :py:class:`RegistryPatcher`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ author = 'Phoenix Zerin'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en-US'
+language = 'en-NZ'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ author = 'Phoenix Zerin'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en-US'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -74,7 +74,6 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
-
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -94,12 +93,10 @@ todo_include_todos = False
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'class-registrydoc'
-
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -126,9 +123,8 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'class-registry.tex', 'class-registry Documentation',
-     'Phoenix Zerin', 'manual'),
+    'Phoenix Zerin', 'manual'),
 ]
-
 
 # -- Options for manual page output ---------------------------------------
 
@@ -136,9 +132,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (master_doc, 'classregistry', 'class-registry Documentation',
-     [author], 1)
+    [author], 1)
 ]
-
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -147,9 +142,6 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'class-registry', 'class-registry Documentation',
-     author, 'class-registry', 'One line description of project.',
-     'Miscellaneous'),
+    author, 'class-registry', 'One line description of project.',
+    'Miscellaneous'),
 ]
-
-
-

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -82,14 +82,15 @@ What happens if two classes have the same registry key?
    assert isinstance(janet, Ivysaur)
 
 As you can see, if two (or more) classes have the same registry key, whichever
-one is registered last will override any the other(s).
+one is registered last will override any of the other(s).
 
 .. note::
 
     It is not always easy to predict the order in which classes will be
-    registered, especially when they are spread across different modules!
+    registered, especially when they are spread across different modules, so you
+    probably don't want to rely on this behaviour!
 
-If you don't want this behavior, you can pass ``unique=True`` to the
+If you want to prevent collisions, you can pass ``unique=True`` to the
 :py:class:`ClassRegistry` initializer to raise an exception whenever a collision
 occurs:
 
@@ -113,7 +114,8 @@ occurs:
    janet = pokedex['grass']
    assert isinstance(janet, Bulbasaur)
 
-Attempting to register ``Ivysaur`` with the same registry key as ``Bulbasaur``
+Because we passed ``unique=True`` to the :py:class:`ClassRegistry` initialiser,
+attempting to register ``Ivysaur`` with the same registry key as ``Bulbasaur``
 raised a :py:class:`RegistryKeyError`, so it didn't override ``Bulbasaur``.
 
 Init Params
@@ -129,7 +131,7 @@ a new instance:
    assert marlene is not charlene
 
 Since you're creating a new instance every time, you also have the option of
-providing args and kwargs to the class initializer using the registry's
+providing args and kwargs to the class initialiser using the registry's
 :py:meth:`get` method:
 
 .. code-block:: python
@@ -154,7 +156,7 @@ providing args and kwargs to the class initializer using the registry's
    assert tammy.level == 42
 
 Any arguments that you provide to :py:meth:`get` will be passed directly to the
-corresponding class' initializer.
+corresponding class' initialiser.
 
 .. hint::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,3 +88,8 @@ Installation
 Install the latest stable version via pip::
 
    pip install phx-class-registry
+
+.. important::
+   Make sure to install `phx-class-registry`, **not** `class-registry`.  I
+   created the latter at a previous job years ago, and after I left they never
+   touched that project again — so in the end I had to fork it 🤷

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,21 +73,18 @@ To learn more about what you can do with ClassRegistry,
 
 Requirements
 ------------
-ClassRegistry is compatible with the following Python versions:
+ClassRegistry is known to be compatible with the following Python versions:
 
-- 3.8
-- 3.7
-- 3.6
-- 3.5
-
-pypy3 is also supported.
+- 3.11
+- 3.10
+- 3.9
 
 .. note::
-  ClassRegistry is **not** compatible with Python 2.
+   ClassRegistry's code is pretty simple, so it's likely to be compatible with
+   versions not listed here; there's just no test coverage to prove it 😇
 
 Installation
 ------------
 Install the latest stable version via pip::
 
    pip install phx-class-registry
-

--- a/docs/iterating_over_registries.rst
+++ b/docs/iterating_over_registries.rst
@@ -99,7 +99,8 @@ the items are sorted:
      """
      Sorts items by weight, using registry key as a tiebreaker.
 
-     ``a`` and ``b`` are tuples of (registry key, class)``.
+     :param a: Tuple of (key, class)
+     :param b: Tuple of (key, class)
      """
      # Sort descending by weight first.
      weight_cmp = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+# :see: https://peps.python.org/pep-0621/
+
+[project]
+name = "phx-class-registry"
+version = "4.0.0"
+description = "Factory+Registry pattern for Python classes"
+readme = "README.rst"
+requires-python = ">= 3"
+license = { file = "LICENCE.txt" }
+authors = [
+    { email = "Phoenix Zerin <phx@phx.nz>" }
+]
+keywords = [
+    "design pattern",
+    "factory pattern",
+    "registry pattern",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.optional-dependencies]
+"build-system" = ["build", "twine"]
+"docs-builder" = ["sphinx", "sphinx_rtd_theme"]
+"test-runner" = ["tox"]
+
+[project.urls]
+documentation = "https://class-registry.readthedocs.io/"
+repository = "https://github.com/todofixthis/class-registry"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "phx-class-registry"
-version = "4.0.0"
+version = "4.0.1"
 description = "Factory+Registry pattern for Python classes"
 readme = "README.rst"
 requires-python = ">= 3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "phx-class-registry"
-version = "4.0.1"
+version = "4.0.2"
 description = "Factory+Registry pattern for Python classes"
 readme = "README.rst"
 requires-python = ">= 3"
@@ -33,5 +33,5 @@ classifiers = [
 "test-runner" = ["tox"]
 
 [project.urls]
-documentation = "https://class-registry.readthedocs.io/"
-repository = "https://github.com/todofixthis/class-registry"
+Documentation = "https://class-registry.readthedocs.io/"
+Repository = "https://github.com/todofixthis/class-registry"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "phx-class-registry"
-version = "4.0.2"
+version = "4.0.3"
 description = "Factory+Registry pattern for Python classes"
 readme = "README.rst"
 requires-python = ">= 3"

--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,5 @@
-from codecs import StreamReader, open
-from os.path import dirname, join, realpath
-
 from setuptools import setup
 
-cwd = dirname(realpath(__file__))
-
-##
-# Load long description for PyPi.
-with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f:  # type: StreamReader
-    long_description = f.read()
-
-##
-# Off we go!
-setup(
-    name='phx-class-registry',
-    description='Factory+Registry pattern for Python classes.',
-    url='https://class-registry.readthedocs.io/',
-
-    version='4.0.0',
-
-    packages=['class_registry'],
-
-    long_description=long_description,
-
-    install_requires=[],
-
-    extras_require={
-        'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
-        'test-runner':  ['nose2', 'tox'],
-    },
-
-    license='MIT',
-
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-
-    keywords='factory registry design pattern',
-
-    author='Phoenix Zerin',
-    author_email='phx@phx.ph',
-)
+if __name__ == '__main__':
+    # :see: https://stackoverflow.com/a/62983901
+    setup()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description='Factory+Registry pattern for Python classes.',
     url='https://class-registry.readthedocs.io/',
 
-    version='3.0.5',
+    version='4.0.0',
 
     packages=['class_registry'],
 
@@ -27,12 +27,8 @@ setup(
 
     extras_require={
         'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
-        'test-runner':  ['tox >= 3.7'],
+        'test-runner':  ['nose2', 'tox'],
     },
-
-    test_suite='test',
-    test_loader='nose.loader:TestLoader',
-    tests_require=['nose'],
 
     license='MIT',
 
@@ -41,15 +37,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 
-    keywords='registry pattern',
+    keywords='factory registry design pattern',
 
     author='Phoenix Zerin',
     author_email='phx@phx.ph',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,7 @@
 class Pokemon(object):
     """
-    A basic class with some attributes that we can use to test out
-    class registries.
+    A basic class with some attributes that we can use to test out class
+    registries.
     """
     element = None
 

--- a/test/auto_register_test.py
+++ b/test/auto_register_test.py
@@ -64,8 +64,7 @@ class AutoRegisterTestCase(TestCase):
 
     def test_abstract_strict_definition(self):
         """
-        If a class has no unimplemented abstract methods, it gets
-        registered.
+        If a class has no unimplemented abstract methods, it gets registered.
         """
         registry = ClassRegistry(attr_name='element')
 

--- a/test/cache_test.py
+++ b/test/cache_test.py
@@ -15,8 +15,8 @@ class ClassRegistryInstanceCacheTestCase(TestCase):
     def test_get(self):
         """
         When an instance is returned from
-        :py:meth:`ClassRegistryInstanceCache.get`, future invocations
-        return the same instance.
+        :py:meth:`ClassRegistryInstanceCache.get`, future invocations return
+        the same instance.
         """
         # Register a few classes with the ClassRegistry.
         self.registry.register(Bulbasaur)
@@ -41,8 +41,8 @@ class ClassRegistryInstanceCacheTestCase(TestCase):
 
     def test_template_args(self):
         """
-        Extra params passed to the cache constructor are passed to the
-        template function when creating new instances.
+        Extra params passed to the cache constructor are passed to the template
+        function when creating new instances.
         """
         self.registry.register(Charmeleon)
         self.registry.register(Wartortle)

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -9,12 +9,12 @@ from test import Bulbasaur, Charmander, Mew, PokemonFactory, Squirtle
 
 def setUpModule():
     #
-    # Install a fake distribution that we can use to inject entry
-    # points at runtime.
+    # Install a fake distribution that we can use to inject entry points at
+    # runtime.
     #
-    # The side effects from this are pretty severe, but they (very
-    # probably) only impact this test, and they are undone as soon as
-    # the process terminates.
+    # The side effects from this are pretty severe, but they (very probably)
+    # only impact this test, and they are undone as soon as the process
+    # terminates.
     #
     working_set.add_entry(dirname(__file__))
 
@@ -40,8 +40,8 @@ class EntryPointClassRegistryTestCase(TestCase):
         self.assertIsInstance(water, Squirtle)
         self.assertEqual(water.name, 'archibald')
 
-        # The 'psychic' entry point actually references a function, but
-        # it works exactly the same as a class.
+        # The 'psychic' entry point actually references a function, but it
+        # works exactly the same as a class.
         psychic = registry.get('psychic', 'snuggles')
         self.assertIsInstance(psychic, Mew)
         self.assertEqual(psychic.name, 'snuggles')
@@ -61,8 +61,8 @@ class EntryPointClassRegistryTestCase(TestCase):
             self.assertEqual(registry['fire'].poke_type, 'fire')
             self.assertEqual(registry.get('water', 'phil').poke_type, 'water')
 
-            # Registered functions and methods can't be branded this
-            # way, though...
+            # Registered functions and methods can't be branded this way,
+            # though...
             self.assertFalse(
                 hasattr(PokemonFactory.create_psychic_pokemon, 'poke_type'),
             )
@@ -96,10 +96,11 @@ class EntryPointClassRegistryTestCase(TestCase):
 
     def test_error_wrong_group(self):
         """
-        The registry can't find entry points associated with the wrong
+        The registry can't find entry points associated with the wrong group.
         """
+        # Pokémon get registered (unsurprisingly) under the ``pokemon`` group,
+        # not ``random``.
         registry = EntryPointClassRegistry('random')
 
         with self.assertRaises(RegistryKeyError):
-            # The dummy project registers
             registry.get('fire')

--- a/test/patcher_test.py
+++ b/test/patcher_test.py
@@ -38,8 +38,7 @@ class RegistryPatcherTestCase(TestCase):
 
     def test_patch_manual_keys(self):
         """
-        Patching a registry in a context, specifying registry keys
-        manually.
+        Patching a registry in a context, specifying registry keys manually.
         """
         self.registry.register('sparky')(Charmander)
         self.registry.register('chad')(Squirtle)

--- a/test/registry_test.py
+++ b/test/registry_test.py
@@ -111,7 +111,7 @@ class ClassRegistryTestCase(TestCase):
 
         .. note::
            This is not used that often outside unit tests (e.g., to remove
-           artifacts when a test has to add a class to a global registry).
+           artefacts when a test has to add a class to a global registry).
         """
         registry = ClassRegistry(attr_name='element')
         registry.register(Charmander)

--- a/test/registry_test.py
+++ b/test/registry_test.py
@@ -10,8 +10,8 @@ from test import Bulbasaur, Charmander, Charmeleon, Pokemon, \
 class ClassRegistryTestCase(TestCase):
     def test_register_manual_keys(self):
         """
-        Registers a few classes with manually-assigned identifiers and
-        verifies that the factory returns them correctly.
+        Registers a few classes with manually-assigned identifiers and verifies
+        that the factory returns them correctly.
         """
         registry = ClassRegistry()
 
@@ -23,9 +23,9 @@ class ClassRegistryTestCase(TestCase):
         class Blastoise(Pokemon):
             pass
 
-        # By default, you have to specify a registry key when
-        # registering new classes.  We'll see how to assign
-        # registry keys automatically in the next test.
+        # By default, you have to specify a registry key when registering new
+        # classes.  We'll see how to assign registry keys automatically in the
+        # next test.
         with self.assertRaises(ValueError):
             # noinspection PyUnusedLocal
             @registry.register
@@ -37,9 +37,8 @@ class ClassRegistryTestCase(TestCase):
 
     def test_register_detect_keys(self):
         """
-        If an attribute name is passed to ClassRegistry's constructor,
-        it will automatically check for this attribute when
-        registering classes.
+        If an attribute name is passed to ClassRegistry's constructor, it will
+        automatically check for this attribute when registering classes.
         """
         registry = ClassRegistry(attr_name='element')
 
@@ -97,17 +96,16 @@ class ClassRegistryTestCase(TestCase):
 
     def test_unique_keys(self):
         """
-        Specifying ``unique=True`` when creating the registry requires
-        all keys to be unique.
+        Specifying ``unique=True`` when creating the registry requires all keys
+        to be unique.
         """
         registry = ClassRegistry(attr_name='element', unique=True)
 
         # We can register any class like normal...
-        # noinspection PyUnusedLocal
         registry.register(Charmander)
 
-        # ... but if we try to register a second class with the same
-        # key, we get an error.
+        # ... but if we try to register a second class with the same key, we
+        # get an error.
         with self.assertRaises(RegistryKeyError):
             registry.register(Charmeleon)
 
@@ -115,15 +113,13 @@ class ClassRegistryTestCase(TestCase):
         """
         Removing a class from the registry.
 
-        This is not used that often outside of unit tests (e.g., to
-        remove artifacts when a test has to add a class to a global
-        registry).
+        .. note::
+           This is not used that often outside unit tests (e.g., to remove
+           artifacts when a test has to add a class to a global registry).
         """
         registry = ClassRegistry(attr_name='element')
         registry.register(Charmander)
         registry.register(Squirtle)
-
-        # Don't feel bad Bulbasaur!  Actually, you're my favorite!
 
         self.assertIs(registry.unregister('fire'), Charmander)
 
@@ -132,7 +128,6 @@ class ClassRegistryTestCase(TestCase):
 
         # Note that you must unregister the KEY, not the CLASS.
         with self.assertRaises(KeyError):
-            # noinspection PyTypeChecker
             registry.unregister(Squirtle)
 
         # If you try to unregister a key that isn't registered, you'll
@@ -147,12 +142,12 @@ class ClassRegistryTestCase(TestCase):
         registry = ClassRegistry(attr_name='element')
         registry.register(Bulbasaur)
 
-        # Goofus uses positional arguments, which are magical and
-        # make his code more difficult to read.
+        # Goofus uses positional arguments, which are magical and make his code
+        # more difficult to read.
         goofus = registry.get('grass', 'goofus')
 
-        # Gallant uses keyword arguments, producing self-documenting
-        # code and being courteous to his fellow developers.
+        # Gallant uses keyword arguments, producing self-documenting code and
+        # being courteous to his fellow developers.
         # He still names his pokémon after himself, though. Narcissist.
         gallant = registry.get('grass', name='gallant')
 
@@ -164,8 +159,7 @@ class ClassRegistryTestCase(TestCase):
 
     def test_new_instance_every_time(self):
         """
-        Every time a registered class is invoked, a new instance is
-        returned.
+        Every time a registered class is invoked, a new instance is returned.
         """
         registry = ClassRegistry(attr_name='element')
         registry.register(Wartortle)
@@ -174,8 +168,8 @@ class ClassRegistryTestCase(TestCase):
 
     def test_register_function(self):
         """
-        Functions can be registered as well (so long as they walk, talk
-        and quack like a class).
+        Functions can be registered as well (so long as they walk and quack
+        like a class).
         """
         registry = ClassRegistry()
 
@@ -208,14 +202,13 @@ class ClassRegistryTestCase(TestCase):
 class SortedClassRegistryTestCase(TestCase):
     def test_sort_key(self):
         """
-        When iterating over a SortedClassRegistry, classes are returned
-        in sorted order rather than inclusion order.
+        When iterating over a SortedClassRegistry, classes are returned in
+        sorted order rather than inclusion order.
         """
-        registry = \
-            SortedClassRegistry(
-                attr_name='element',
-                sort_key='weight',
-            )
+        registry = SortedClassRegistry(
+            attr_name='element',
+            sort_key='weight',
+        )
 
         @registry.register
         class Geodude(Pokemon):
@@ -232,8 +225,8 @@ class SortedClassRegistryTestCase(TestCase):
             element = 'grass'
             weight = 15
 
-        # The registry iterates over registered classes in ascending
-        # order by ``weight``.
+        # The registry iterates over registered classes in ascending order by
+        # ``weight``.
         self.assertListEqual(
             list(registry.values()),
             [Bellsprout, Machop, Geodude],
@@ -243,12 +236,11 @@ class SortedClassRegistryTestCase(TestCase):
         """
         Reversing the order of a sort key.
         """
-        registry = \
-            SortedClassRegistry(
-                attr_name='element',
-                sort_key='weight',
-                reverse=True,
-            )
+        registry = SortedClassRegistry(
+            attr_name='element',
+            sort_key='weight',
+            reverse=True,
+        )
 
         @registry.register
         class Geodude(Pokemon):
@@ -265,8 +257,8 @@ class SortedClassRegistryTestCase(TestCase):
             element = 'grass'
             weight = 15
 
-        # The registry iterates over registered classes in descending
-        # order by ``weight``.
+        # The registry iterates over registered classes in descending order by
+        # ``weight``.
         self.assertListEqual(
             list(registry.values()),
             [Geodude, Machop, Bellsprout],
@@ -285,11 +277,10 @@ class SortedClassRegistryTestCase(TestCase):
                     - (a[1].popularity > b[1].popularity)
             )
 
-        registry = \
-            SortedClassRegistry(
-                attr_name='element',
-                sort_key=cmp_to_key(compare_pokemon),
-            )
+        registry = SortedClassRegistry(
+            attr_name='element',
+            sort_key=cmp_to_key(compare_pokemon),
+        )
 
         @registry.register
         class Onix(Pokemon):
@@ -306,8 +297,8 @@ class SortedClassRegistryTestCase(TestCase):
             element = 'grass'
             popularity = 10
 
-        # The registry iterates over registered classes in descending
-        # order by ``popularity``.
+        # The registry iterates over registered classes in descending order by
+        # ``popularity``.
         self.assertListEqual(
             list(registry.values()),
             [Cubone, Onix, Exeggcute],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,2 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py35, py36, py37, py38, pypy3
-
-[testenv]
-commands = python setup.py test
+envlist = py3{11,10,9}


### PR DESCRIPTION
# ⚠️ Backwards-Incompatible Changes
**The following changes only impact you if your code defines its own class registry subclasses.  If you do not subclass any of the class registry classes (e.g., if you're not doing `class MyClassRegistry(ClassRegistry):` anywhere in your code), you do not have to do anything.**

* Renamed `class_registry.MutableRegistry` to `class_registry.BaseMutableRegistry`.
    * If you are subclassing `MutableRegistry` in your code, change the base class to `BaseMutableRegistry` instead.
    * If you are not subclassing `MutableRegistry`, you don't have to do anything.
* When a class registry overrides `gen_lookup_keys`, the `__iter__`, `items`, and `keys` methods iterate over the human-readable keys, not the lookup keys.
    * Contrived example: if a subclass overrides `gen_lookup_key` to return a hash of the key:
        * Previous version:  The hashed keys would be included in the output from `items`, etc.
        * This version:  The original un-hashed keys would be included instead.
    * See `test.registry_test.GenLookupKeyTestCase` for more information and examples.
    * If your code subclasses any of the class registry classes and it overrides the `gen_lookup_key` method, you may 
need to update any code that iterates over keys/items in that registry.
    * If you are not overriding the `gen_lookup_key` method, you do not have to do anything.
* `SortedClassRegistry` now provides both the human-readable key and the lookup key to sorting functions.
    * Contrived example: if a subclass overrides `gen_lookup_key` to return a hash of the key:
        * Previous version:  The hashed keys would be used for sorting.
        * This version:  The original un-hashed keys would be used instead.
    * See `test.registry_test.SortedClassRegistryTestCase.test_gen_lookup_key_overridden` for more information.
    * If your code subclasses `SortedClassRegistry` and overrides the `gen_lookup_key` method, you may need to update the sorting function, as the arguments that get passed to it will have a slightly different structure (refer to the test referenced above to see an example).
    * If you are not overriding the `gen_lookup_key` method, you do not have to do anything.
* Changed type hint for `items`, `keys`, and `values` methods; these should now return a generator rather than an iterable.
    * This shouldn't break existing code, but if you have code that overrides these methods, you may want to update them to prevent potential (but unlikely 😇) issues in future versions of `phx-class-registry`.
    * If you are not overriding any of these methods, you do not have to do anything.

# Changelog
* Switched official support to Python 3.11, 3.10, and 3.9 (but older versions are supported unofficially).
* Fixed incorrect documentation for the `unique` parameter for `ClassRegistry.__init__` (thanks @adrian-nilsson-fcc!).
* Added test coverage for overridden `gen_lookup_key`.
* Added documentation for overriding `gen_lookup_key` in subclasses.
* Added missing type hints and fixed some incorrect type hints.
* Translate documentation to NZ English 🇳🇿
* Added release instructions to README.