### PR TITLE
ClassRegistry 4.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
         python-version:
           # Note: Use quotes to avoid float cast - especially important if the
           # version number ends with 0!
-          - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - name: Clone Repo

--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,9 @@ Requirements
 ------------
 ClassRegistry is known to be compatible with the following Python versions:
 
+- 3.12
 - 3.11
 - 3.10
-- 3.9
 
 .. note::
    I'm only one person, so to keep from getting overwhelmed, I'm only committing

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://github.com/todofixthis/class-registry/actions/workflows/build.yml/badge.svg
+   :target: https://github.com/todofixthis/class-registry/actions/workflows/build.yml
 .. image:: https://readthedocs.org/projects/class-registry/badge/?version=latest
    :target: http://class-registry.readthedocs.io/
 

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -1,6 +1,6 @@
-import typing
+from importlib.metadata import entry_points
 
-from pkg_resources import iter_entry_points
+import typing
 
 from . import BaseRegistry
 
@@ -97,7 +97,7 @@ class EntryPointClassRegistry(BaseRegistry):
         """
         if self._cache is None:
             self._cache = {}
-            for e in iter_entry_points(self.group):
+            for e in entry_points(group=self.group):
                 cls = e.load()
 
                 # Try to apply branding, but only for compatible types (i.e.,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "phx-class-registry"
 version = "4.0.6"
 description = "Factory+Registry pattern for Python classes"
 readme = "README.rst"
-requires-python = ">= 3"
+requires-python = ">= 3.10"
 license = { file = "LICENCE.txt" }
 authors = [
     { email = "Phoenix Zerin <phx@phx.nz>" }
@@ -20,9 +20,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.9",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -1,0 +1,41 @@
+import sys
+from importlib.metadata import DistributionFinder, PathDistribution
+from os import path
+from pathlib import Path
+
+
+class DummyDistributionFinder(DistributionFinder):
+    """
+    Injects a dummy distribution into the meta path finder, so that we can
+    pretend like it's been pip installed during unit tests (i.e., so that we
+    can test ``EntryPointsClassRegistry``), without polluting the persistent
+    virtualenv.
+    """
+
+    DUMMY_PACKAGE_DIR = 'dummy_package.egg-info'
+
+    @classmethod
+    def install(cls):
+        for finder in sys.meta_path:
+            if isinstance(finder, cls):
+                # If we've already installed an instance of the class, then
+                # something is probably wrong with our tests.
+                raise ValueError(f'{cls.__name__} is already installed')
+
+        sys.meta_path.append(cls())
+
+    @classmethod
+    def uninstall(cls):
+        for i, finder in enumerate(sys.meta_path):
+            if isinstance(finder, cls):
+                sys.meta_path.pop(i)
+                return
+        else:
+            # If we didn't find an installed instance of the class, then
+            # something is probably wrong with our tests.
+            raise ValueError(f'{cls.__name__} was not installed')
+
+    def find_distributions(self, context=...) -> list[PathDistribution]:
+        return [PathDistribution(
+            Path(path.join(path.dirname(__file__), self.DUMMY_PACKAGE_DIR))
+        )]

--- a/test/test_entry_points.py
+++ b/test/test_entry_points.py
@@ -1,22 +1,18 @@
-from os.path import dirname
+from importlib.metadata import entry_points
 from unittest import TestCase
-
-from pkg_resources import iter_entry_points, working_set
 
 from class_registry import EntryPointClassRegistry, RegistryKeyError
 from test import Bulbasaur, Charmander, Mew, PokemonFactory, Squirtle
+from test.helper import DummyDistributionFinder
 
 
 def setUpModule():
-    #
-    # Install a fake distribution that we can use to inject entry points at
-    # runtime.
-    #
-    # The side effects from this are pretty severe, but they (very probably)
-    # only impact this test, and they are undone as soon as the process
-    # terminates.
-    #
-    working_set.add_entry(dirname(__file__))
+    # Inject a distribution that defines some entry points.
+    DummyDistributionFinder.install()
+
+
+def tearDownModule():
+    DummyDistributionFinder.uninstall()
 
 
 class EntryPointClassRegistryTestCase(TestCase):
@@ -85,7 +81,7 @@ class EntryPointClassRegistryTestCase(TestCase):
         """
         # Just in case some other package defines pokémon entry
         # points (:
-        expected = len(list(iter_entry_points('pokemon')))
+        expected = len(list(entry_points(group='pokemon')))
 
         # Quick sanity check, to make sure our test pokémon are
         # registered correctly.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{11,10,9}
+envlist = py3{12,11,10}
 
 [testenv]
 commands = python -m unittest


### PR DESCRIPTION
⚠️ This release drops support for Python 3.9 ⚠️

* Add support for Python 3.12, drop support for Python 3.9.
* Added GitHub Actions badge to README.