### PR TITLE
Added `.readthedocs.yaml` 🍠

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
* Fixed RTD build errors due to now-required `.readthedocs.yaml` file.