### PR TITLE
ClassRegistry v4.1.1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,5 +6,9 @@ build:
   tools:
     python: "3.11"
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#id6
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
⚠️ This release drops support for Python 3.9 ⚠️

* Add support for Python 3.12, drop support for Python 3.9.
* Added GitHub Actions badge to README.
* Added documentation build step to GitHub Actions (to check for build warnings/errors only).
* Added now-required `readthedocs.yaml` file for RTD documentation builds.