### PR TITLE
ClassRegistry v4.1.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,13 +75,15 @@ Requirements
 ------------
 ClassRegistry is known to be compatible with the following Python versions:
 
+- 3.12
 - 3.11
 - 3.10
-- 3.9
 
 .. note::
-   ClassRegistry's code is pretty simple, so it's likely to be compatible with
-   versions not listed here; there's just no test coverage to prove it 😇
+   I'm only one person, so to keep from getting overwhelmed, I'm only committing
+   to supporting the 3 most recent versions of Python.  ClassRegistry's code is
+   pretty simple, so it's likely to be compatible with versions not listed here;
+   there just won't be any test coverage to prove it 😇
 
 Installation
 ------------


### PR DESCRIPTION
Screw it; I'm starting over 😹

⚠️ This release drops support for Python 3.9 ⚠️

* Add support for Python 3.12, drop support for Python 3.9.
* Added GitHub Actions badge to README.
* Added documentation build step to GitHub Actions (to check for build warnings/errors only).
* Added now-required `readthedocs.yaml` file for RTD documentation builds.