### PR TITLE
[#14] `AutoRegister` now returns base class instead of metaclass

### DIFF
--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -55,9 +55,7 @@ def AutoRegister(registry: BaseMutableRegistry, base_type: type = ABCMeta) -> ty
     )
 
     if not registry.attr_name:
-        raise ValueError(
-            "Missing `attr_name` in {registry}.".format(registry=registry),
-        )
+        raise ValueError(f"Missing `attr_name` in {registry}.")
 
     class _metaclass(base_type):
         def __init__(self, what, bases=None, attrs=None):

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta
 from inspect import isabstract as is_abstract
+from warnings import warn
 
 from .base import BaseMutableRegistry
 
@@ -45,6 +46,14 @@ def AutoRegister(registry: BaseMutableRegistry, base_type: type = ABCMeta) -> ty
 
         99.99% of the time, this should be :py:class:`ABCMeta`.
     """
+    warn(
+        "class_registry.auto_register.AutoRegister is deprecated and will be removed in"
+        "a future version of ClassRegistry.  Use class_registry.base.AutoRegister"
+        "instead (returns a base class instead of a metaclass).  See"
+        "https://github.com/todofixthis/class-registry/issues/14 for more information.",
+        DeprecationWarning,
+    )
+
     if not registry.attr_name:
         raise ValueError(
             "Missing `attr_name` in {registry}.".format(registry=registry),

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -15,9 +15,6 @@ def AutoRegister(registry: BaseMutableRegistry, base_type: type = ABCMeta) -> ty
     Creates a metaclass that automatically registers all non-abstract subclasses in the
     specified registry.
 
-    IMPORTANT:  Python defines abstract as "having at least one unimplemented abstract
-    method"; adding :py:class:`ABC` as a base class is not enough!
-
     Example::
 
        commands = ClassRegistry(attr_name='command_name')
@@ -36,15 +33,22 @@ def AutoRegister(registry: BaseMutableRegistry, base_type: type = ABCMeta) -> ty
 
        print(list(commands.items())) # [('print', PrintCommand)]
 
+    .. important::
+
+       Python defines abstract as "having at least one unimplemented abstract method";
+       adding :py:class:`abc.ABC` as a base class is not enough.
+
     :param registry:
         The registry that new classes will be added to.
 
-        Note: the registry's ``attr_name`` attribute must be set!
+        .. note::
+
+           The registry's ``attr_name`` attribute must be set.
 
     :param base_type:
         The base type of the metaclass returned by this function.
 
-        99.99% of the time, this should be :py:class:`ABCMeta`.
+        99.99% of the time, this should be :py:class:`abc.ABCMeta`.
     """
     warn(
         "class_registry.auto_register.AutoRegister is deprecated and will be removed in"

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -1,22 +1,22 @@
+__all__ = ["AutoRegister"]
+
 from abc import ABCMeta
 from inspect import isabstract as is_abstract
 from warnings import warn
 
 from .base import BaseMutableRegistry
 
-__all__ = [
-    "AutoRegister",
-]
-
 
 def AutoRegister(registry: BaseMutableRegistry, base_type: type = ABCMeta) -> type:
     """
-    Creates a metaclass that automatically registers all non-abstract
-    subclasses in the specified registry.
+    DEPRECATED: Use ``class_registry.base.AutoRegister`` instead (returns a base class
+    instead of a metaclass).
 
-    IMPORTANT:  Python defines abstract as "having at least one unimplemented
-    abstract method"; specifying :py:class:`ABCMeta` as the metaclass is not
-    enough!
+    Creates a metaclass that automatically registers all non-abstract subclasses in the
+    specified registry.
+
+    IMPORTANT:  Python defines abstract as "having at least one unimplemented abstract
+    method"; adding :py:class:`ABC` as a base class is not enough!
 
     Example::
 

--- a/class_registry/base.py
+++ b/class_registry/base.py
@@ -1,20 +1,22 @@
+__all__ = ["AutoRegister", "BaseMutableRegistry", "BaseRegistry", "RegistryKeyError"]
+
 import typing
-from abc import ABCMeta, abstractmethod as abstract_method
-from inspect import isclass as is_class
+from abc import ABC, abstractmethod as abstract_method
+from inspect import isabstract, isclass as is_class
 
 
 class RegistryKeyError(KeyError):
     """
     Used to differentiate a registry lookup from a standard KeyError.
 
-    This is especially useful when a registry class expects to extract values
-    from dicts to generate keys.
+    This is especially useful when a registry class expects to extract values from dicts
+    to generate keys.
     """
 
     pass
 
 
-class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
+class BaseRegistry(typing.Mapping, ABC):
     """
     Base functionality for registries.
     """
@@ -24,10 +26,9 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
         Returns whether the specified key is registered.
         """
         try:
-            # Use :py:meth:`get_class` instead of :py:meth:`__getitem__`, to
-            # avoid creating a new instance unnecessarily (i.e., prevent
-            # errors if the corresponding class' constructor requires
-            # arguments).
+            # Use :py:meth:`get_class` instead of :py:meth:`__getitem__`, to avoid
+            # creating a new instance unnecessarily (i.e., prevent errors if the
+            # corresponding class' constructor requires arguments).
             self.get_class(key)
         except RegistryKeyError:
             return False
@@ -45,8 +46,8 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
 
     def __iter__(self) -> typing.Generator[typing.Hashable, None, None]:
         """
-        Returns a generator for iterating over registry keys, in the
-        order that they were registered.
+        Returns a generator for iterating over registry keys, in the order that they
+        were registered.
         """
         return self.keys()
 
@@ -63,8 +64,8 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
         """
         Defines what to do when trying to access an unregistered key.
 
-        Default behaviour is to throw a typed exception, but you could override
-        this in a subclass, e.g., to return a default value.
+        Default behaviour is to throw a typed exception, but you could override this in
+        a subclass, e.g., to return a default value.
         """
         raise RegistryKeyError(key)
 
@@ -86,13 +87,11 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
 
         :param args:
             Positional arguments passed to class initializer.
-            Ignored if the class registry was initialized with a null template
-            function.
+            Ignored if the class registry was initialized with a null template function.
 
         :param kwargs:
             Keyword arguments passed to class initializer.
-            Ignored if the class registry was initialized with a null template
-            function.
+            Ignored if the class registry was initialized with a null template function.
 
         References:
           - :py:meth:`__init__`
@@ -104,8 +103,8 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
         """
         Used by :py:meth:`get` to generate a lookup key.
 
-        You may override this method in a subclass, for example if you need to
-        support legacy aliases, etc.
+        You may override this method in a subclass, for example if you need to support
+        legacy aliases, etc.
         """
         return key
 
@@ -114,8 +113,8 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
         """
         Prepares the return value for :py:meth:`get`.
 
-        You may override this method in a subclass, if you want to customize
-        the way new instances are created.
+        You may override this method in a subclass, if you want to customize the way new
+        instances are created.
 
         :param class_:
             The requested class.
@@ -133,8 +132,8 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
         self,
     ) -> typing.Generator[typing.Tuple[typing.Hashable, type], None, None]:
         """
-        Iterates over registered classes and their corresponding keys, in the
-        order that they were registered.
+        Iterates over registered classes and their corresponding keys, in the order that
+        they were registered.
         """
         raise NotImplementedError(
             "Not implemented in {cls}.".format(cls=type(self).__name__),
@@ -142,40 +141,40 @@ class BaseRegistry(typing.Mapping, metaclass=ABCMeta):
 
     def keys(self) -> typing.Generator[typing.Hashable, None, None]:
         """
-        Returns a generator for iterating over registry keys, in the order that
-        they were registered.
+        Returns a generator for iterating over registry keys, in the order that they
+        were registered.
         """
         for item in self.items():
             yield item[0]
 
     def values(self) -> typing.Generator[type, None, None]:
         """
-        Returns a generator for iterating over registered classes, in the order
-        that they were registered.
+        Returns a generator for iterating over registered classes, in the order that
+        they were registered.
         """
         for item in self.items():
             yield item[1]
 
 
-class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, metaclass=ABCMeta):
+class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, ABC):
     """
-    Extends :py:class:`BaseRegistry` with methods that can be used to modify
-    the registered classes.
+    Extends :py:class:`BaseRegistry` with methods that can be used to modify the
+    registered classes.
     """
 
     def __init__(self, attr_name: typing.Optional[str] = None) -> None:
         """
         :param attr_name:
-            If provided, :py:meth:`register` will automatically detect the key
-            to use when registering new classes.
+            If provided, :py:meth:`register` will automatically detect the key to use
+            when registering new classes.
         """
         super(BaseMutableRegistry, self).__init__()
 
         self.attr_name = attr_name
 
         # Map lookup keys to readable keys.
-        # Only needed when :py:meth:`gen_lookup_key` is overridden, but I'm not
-        # good enough at reflection black magic to figure out how to do that (:
+        # Only needed when :py:meth:`gen_lookup_key` is overridden, but I'm not good
+        # enough at reflection black magic to figure out how to do that (:
         self._lookup_keys: typing.Dict[typing.Hashable, typing.Hashable] = {}
 
     def __delitem__(self, key: typing.Hashable) -> None:
@@ -201,7 +200,8 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, metaclass=ABCMeta
         self._lookup_keys[key] = lookup_key
 
     def register(
-        self, key: typing.Union[typing.Hashable, type]
+        self,
+        key: typing.Union[typing.Hashable, type],
     ) -> typing.Callable[[type], type]:
         """
         Decorator that registers a class with the registry.
@@ -230,27 +230,22 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, metaclass=ABCMeta
                 attr_key = getattr(key, self.attr_name)
                 lookup_key = self.gen_lookup_key(attr_key)
 
-                # Note that ``getattr`` will raise an AttributeError if the
-                # class doesn't have the required attribute.
                 self._register(lookup_key, key)
                 self._lookup_keys[attr_key] = lookup_key
 
                 return key
             else:
                 raise ValueError(
-                    "Attempting to register {cls} to {registry} via decorator,"
-                    " but `{registry}.attr_key` is not set.".format(
-                        cls=key.__name__,
-                        registry=type(self).__name__,
-                    )
+                    f"Attempting to register {key.__name__} to {type(self).__name__}"
+                    f"via decorator, but `{type(self).__name__}.attr_key` is not set."
                 )
 
         # ``@register('some_attr')`` usage:
         def _decorator(cls: type) -> type:
-            lookup_key = self.gen_lookup_key(key)
+            _lookup_key = self.gen_lookup_key(key)
 
-            self._register(lookup_key, cls)
-            self._lookup_keys[key] = lookup_key
+            self._register(_lookup_key, cls)
+            self._lookup_keys[key] = _lookup_key
 
             return cls
 
@@ -295,3 +290,48 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, metaclass=ABCMeta
         raise NotImplementedError(
             "Not implemented in {cls}.".format(cls=type(self).__name__),
         )
+
+
+def AutoRegister(registry: BaseMutableRegistry) -> type:
+    """
+    Creates a base class that automatically registers all non-abstract subclasses in the
+    specified registry.
+
+    IMPORTANT:  Python defines abstract as "having at least one unimplemented abstract
+    method"; adding :py:class:`ABC` as a base class is not enough!
+
+    Example::
+
+       commands = ClassRegistry(attr_name='command_name')
+
+       class BaseCommand(AutoRegister(commands), ABC):
+         @abstractmethod
+         def print(self):
+           raise NotImplementedError()
+
+       class PrintCommand(BaseCommand):
+         command_name = 'print'
+
+         def print(self):
+           ...
+
+       print(list(commands.items())) # [('print', PrintCommand)]
+
+    :param registry:
+        The registry that new classes will be added to.
+
+        Note: the registry's ``attr_name`` attribute must be set!
+    """
+    if not registry.attr_name:
+        raise ValueError(
+            "Missing `attr_name` in {registry}.".format(registry=registry),
+        )
+
+    class _Base:
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+
+            if not isabstract(cls):
+                registry.register(cls)
+
+    return _Base

--- a/class_registry/base.py
+++ b/class_registry/base.py
@@ -56,9 +56,7 @@ class BaseRegistry(typing.Mapping, ABC):
         """
         Returns the number of registered classes.
         """
-        raise NotImplementedError(
-            "Not implemented in {cls}.".format(cls=type(self).__name__),
-        )
+        raise NotImplementedError()
 
     def __missing__(self, key) -> typing.Optional[typing.Any]:
         """
@@ -74,9 +72,7 @@ class BaseRegistry(typing.Mapping, ABC):
         """
         Returns the class associated with the specified key.
         """
-        raise NotImplementedError(
-            "Not implemented in {cls}.".format(cls=type(self).__name__),
-        )
+        raise NotImplementedError()
 
     def get(self, key: typing.Hashable, *args, **kwargs) -> typing.Any:
         """
@@ -135,9 +131,7 @@ class BaseRegistry(typing.Mapping, ABC):
         Iterates over registered classes and their corresponding keys, in the order that
         they were registered.
         """
-        raise NotImplementedError(
-            "Not implemented in {cls}.".format(cls=type(self).__name__),
-        )
+        raise NotImplementedError()
 
     def keys(self) -> typing.Generator[typing.Hashable, None, None]:
         """
@@ -185,10 +179,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, ABC):
         del self._lookup_keys[key]
 
     def __repr__(self) -> str:
-        return "{type}({attr_name!r})".format(
-            attr_name=self.attr_name,
-            type=type(self).__name__,
-        )
+        return f"{type(self).__name__}({self.attr_name!r})"
 
     def __setitem__(self, key: typing.Hashable, class_: type) -> None:
         """
@@ -276,9 +267,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, ABC):
 
         :param key: Has already been processed by :py:meth:`gen_lookup_key`.
         """
-        raise NotImplementedError(
-            "Not implemented in {cls}.".format(cls=type(self).__name__),
-        )
+        raise NotImplementedError()
 
     @abstract_method
     def _unregister(self, key: typing.Hashable) -> type:
@@ -287,9 +276,7 @@ class BaseMutableRegistry(BaseRegistry, typing.MutableMapping, ABC):
 
         :param key: Has already been processed by :py:meth:`gen_lookup_key`.
         """
-        raise NotImplementedError(
-            "Not implemented in {cls}.".format(cls=type(self).__name__),
-        )
+        raise NotImplementedError()
 
 
 def AutoRegister(registry: BaseMutableRegistry) -> type:
@@ -323,9 +310,7 @@ def AutoRegister(registry: BaseMutableRegistry) -> type:
         Note: the registry's ``attr_name`` attribute must be set!
     """
     if not registry.attr_name:
-        raise ValueError(
-            "Missing `attr_name` in {registry}.".format(registry=registry),
-        )
+        raise ValueError(f"Missing `attr_name` in {registry}.")
 
     class _Base:
         def __init_subclass__(cls, **kwargs):

--- a/class_registry/base.py
+++ b/class_registry/base.py
@@ -284,9 +284,6 @@ def AutoRegister(registry: BaseMutableRegistry) -> type:
     Creates a base class that automatically registers all non-abstract subclasses in the
     specified registry.
 
-    IMPORTANT:  Python defines abstract as "having at least one unimplemented abstract
-    method"; adding :py:class:`ABC` as a base class is not enough!
-
     Example::
 
        commands = ClassRegistry(attr_name='command_name')
@@ -304,10 +301,17 @@ def AutoRegister(registry: BaseMutableRegistry) -> type:
 
        print(list(commands.items())) # [('print', PrintCommand)]
 
+    .. important::
+
+       Python defines abstract as "having at least one unimplemented abstract method";
+       adding :py:class:`abc.ABC` as a base class is not enough.
+
     :param registry:
         The registry that new classes will be added to.
 
-        Note: the registry's ``attr_name`` attribute must be set!
+        .. note::
+
+           The registry's ``attr_name`` attribute must be set.
     """
     if not registry.attr_name:
         raise ValueError(f"Missing `attr_name` in {registry}.")

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -1,11 +1,9 @@
+__all__ = ["ClassRegistryInstanceCache"]
+
 import typing
 from collections import defaultdict
 
 from . import ClassRegistry
-
-__all__ = [
-    "ClassRegistryInstanceCache",
-]
 
 
 class ClassRegistryInstanceCache(object):

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -10,13 +10,13 @@ class ClassRegistryInstanceCache(object):
     """
     Wraps a ClassRegistry instance, caching instances as they are created.
 
-    This allows you to create [multiple] registries that cache INSTANCES
-    locally (so that they can be scoped and garbage-collected), while keeping
-    the CLASS registry separate.
+    This allows you to create [multiple] registries that cache instances locally (so
+    that they can be scoped and garbage-collected), whilst keeping the class registry
+    separate.
 
-    Note that the internal class registry is copied by reference, so any
-    classes that are registered afterward are accessible to both the
-    ClassRegistry and the ClassRegistryInstanceCache.
+    Note that the internal class registry is copied by reference, so any classes that
+    are registered afterward are accessible to both the ``ClassRegistry`` and the
+    ``ClassRegistryInstanceCache``.
     """
 
     def __init__(self, class_registry: ClassRegistry, *args, **kwargs) -> None:
@@ -25,12 +25,12 @@ class ClassRegistryInstanceCache(object):
             The wrapped ClassRegistry.
 
         :param args:
-            Positional arguments passed to the class registry's template when
-            creating new instances.
+            Positional arguments passed to the class registry's template when creating
+            new instances.
 
         :param kwargs:
-            Keyword arguments passed to the class registry's template function
-            when creating new instances.
+            Keyword arguments passed to the class registry's template function when
+            creating new instances.
         """
         super(ClassRegistryInstanceCache, self).__init__()
 
@@ -51,8 +51,8 @@ class ClassRegistryInstanceCache(object):
         if instance_key not in self._cache:
             class_key = self.get_class_key(key)
 
-            # Map lookup keys to cache keys so that we can iterate over them in
-            # the correct order.
+            # Map lookup keys to cache keys so that we can iterate over them in the
+            # correct order.
             self._key_map[class_key].append(instance_key)
 
             self._cache[instance_key] = self._registry.get(
@@ -63,8 +63,8 @@ class ClassRegistryInstanceCache(object):
 
     def __iter__(self) -> typing.Generator[type, None, None]:
         """
-        Returns a generator for iterating over cached instances, using the
-        wrapped registry to determine sort order.
+        Returns a generator for iterating over cached instances, using the wrapped
+        registry to determine sort order.
 
         If a key has not been accessed yet, it will not be included.
         """
@@ -74,20 +74,20 @@ class ClassRegistryInstanceCache(object):
 
     def warm_cache(self) -> None:
         """
-        Warms up the cache, ensuring that an instance is created for every key
-        currently in the registry.
+        Warms up the cache, ensuring that an instance is created for every key currently
+        in the registry.
 
         .. note::
-           This method does not account for any classes that may be added to
-           the wrapped ClassRegistry in the future.
+
+           This method has no effect for any classes added to the wrapped
+           :py:class:`ClassRegistry` after calling ``warm_cache``.
         """
         for key in self._registry.keys():
             self.__getitem__(key)
 
     def get_instance_key(self, key: typing.Hashable) -> typing.Hashable:
         """
-        Generates a key that can be used to store/lookup values in the instance
-        cache.
+        Generates a key that can be used to store/lookup values in the instance cache.
 
         :param key:
             Value provided to :py:meth:`__getitem__`.

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -1,11 +1,9 @@
+__all__ = ["EntryPointClassRegistry"]
+
 import typing
 from importlib.metadata import entry_points
 
 from .base import BaseRegistry
-
-__all__ = [
-    "EntryPointClassRegistry",
-]
 
 
 class EntryPointClassRegistry(BaseRegistry):

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -18,16 +18,14 @@ class EntryPointClassRegistry(BaseRegistry):
     ) -> None:
         """
         :param group:
-            The name of the entry point group that will be used to load new
-            classes.
+            The name of the entry point group that will be used to load new classes.
 
         :param attr_name:
-            If set, the registry will "brand" each class with its corresponding
-            registry key.  This makes it easier to perform reverse lookups
-            later.
+            If set, the registry will "brand" each class with its corresponding registry
+            key.  This makes it easier to perform reverse lookups later.
 
-            Note: if a class already defines this attribute, the registry will
-            overwrite it!
+            Note: if a class already defines this attribute, the registry will overwrite
+            it!
         """
         super(EntryPointClassRegistry, self).__init__()
 
@@ -36,12 +34,11 @@ class EntryPointClassRegistry(BaseRegistry):
 
         self._cache: typing.Optional[typing.Dict[typing.Hashable, type]] = None
         """
-        Caches registered classes locally, so that we don't have to keep
-        iterating over entry points.
+        Caches registered classes locally, so that we don't have to keep iterating over
+        entry points.
         """
 
-        # If :py:attr:`attr_name` is set, warm the cache immediately, to apply
-        # branding.
+        # If :py:attr:`attr_name` is set, warm the cache immediately, to apply branding.
         if self.attr_name:
             self._get_cache()
 
@@ -49,18 +46,15 @@ class EntryPointClassRegistry(BaseRegistry):
         return len(self._get_cache())
 
     def __repr__(self) -> str:
-        return "{type}(group={group!r})".format(
-            group=self.group,
-            type=type(self).__name__,
-        )
+        return f"{type(self).__name__}(group={self.group!r})"
 
     def get(self, key: typing.Hashable, *args, **kwargs) -> typing.Any:
         instance = super(EntryPointClassRegistry, self).get(key, *args, **kwargs)
 
         if self.attr_name:
             # Apply branding to the instance explicitly.
-            # This is particularly important if the corresponding entry point
-            # references a function or method.
+            # This is particularly important if the corresponding entry point references
+            # a function or method.
             setattr(instance, self.attr_name, key)
 
         return instance
@@ -78,12 +72,10 @@ class EntryPointClassRegistry(BaseRegistry):
 
     def refresh(self):
         """
-        Purges the local cache.  The next access attempt will reload all entry
-        points.
+        Purges the local cache.  The next access attempt will reload all entry points.
 
-        This is useful if you load a distribution at runtime... such as during
-        unit tests for class-registry.  Otherwise, it probably serves no useful
-        purpose
+        This is useful if you load a distribution at runtime...such as during unit tests
+        for ``phx-class-registry``.  Otherwise, it probably serves no useful purpose (:
         """
         self._cache = None
 
@@ -96,8 +88,8 @@ class EntryPointClassRegistry(BaseRegistry):
             for e in entry_points(group=self.group):
                 cls = e.load()
 
-                # Try to apply branding, but only for compatible types (i.e.,
-                # functions and methods can't be branded this way).
+                # Try to apply branding, but only for compatible types (i.e., functions
+                # and methods can't be branded this way).
                 if self.attr_name and isinstance(cls, type):
                     setattr(cls, self.attr_name, e.name)
 

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -1,11 +1,9 @@
+__all__ = ["RegistryPatcher"]
+
 import typing
 
 from . import RegistryKeyError
 from .base import BaseMutableRegistry
-
-__all__ = [
-    "RegistryPatcher",
-]
 
 
 class RegistryPatcher(object):

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -8,10 +8,12 @@ from .base import BaseMutableRegistry
 
 class RegistryPatcher(object):
     """
-    Creates a context in which classes are temporarily registered with a class
-    registry, then removed when the context exits.
+    Creates a context in which classes are temporarily registered with a class registry,
+    then removed when the context exits.
 
-    Note: only mutable registries can be patched!
+    .. note::
+
+       Only mutable registries can be patched.
     """
 
     class DoesNotExist(object):
@@ -29,10 +31,11 @@ class RegistryPatcher(object):
         :param args:
             Classes to add to the registry.
 
-            This behaves the same as decorating each class with
-            ``@registry.register``.
+            This behaves the same as decorating each class with ``@registry.register``.
 
-            Note: ``registry.attr_name`` must be set!
+            .. note::
+
+               ``registry.attr_name`` must be set.
 
         :param kwargs:
             Same as ``args``, except you explicitly specify the registry keys.
@@ -67,8 +70,8 @@ class RegistryPatcher(object):
 
         # Patch values.
         for key, value in self._new_values.items():
-            # Remove the existing value first (prevents issues if the registry
-            # has ``unique=True``).
+            # Remove the existing value first (prevents issues if the registry has
+            # ``unique=True``).
             self._del_value(key)
 
             if value is not self.DoesNotExist:
@@ -78,10 +81,9 @@ class RegistryPatcher(object):
         """
         Restores previous settings.
         """
-        # Restore previous settings.
         for key, value in self._prev_values.items():
-            # Remove the existing value first (prevents issues if the registry
-            # has ``unique=True``).
+            # Remove the existing value first (prevents issues if the registry has
+            # ``unique=True``).
             self._del_value(key)
 
             if value is not self.DoesNotExist:

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -9,8 +9,8 @@ from .base import BaseMutableRegistry, RegistryKeyError
 
 class ClassRegistry(BaseMutableRegistry):
     """
-    Maintains a registry of classes and provides a generic factory for
-    instantiating them.
+    Maintains a registry of classes and provides a generic factory for instantiating
+    them.
     """
 
     def __init__(
@@ -20,12 +20,11 @@ class ClassRegistry(BaseMutableRegistry):
     ) -> None:
         """
         :param attr_name:
-            If provided, :py:meth:`register` will automatically detect the key
-            to use when registering new classes.
+            If provided, :py:meth:`register` will automatically detect the key to use
+            when registering new classes.
 
         :param unique:
-            Determines what happens when two classes are registered with the
-            same key:
+            Determines what happens when two classes are registered with the same key:
 
             - ``True``: A :py:class:`KeyError` will be raised.
             - ``False``: The second class will replace the first one.
@@ -43,11 +42,7 @@ class ClassRegistry(BaseMutableRegistry):
         return len(self._registry)
 
     def __repr__(self) -> str:
-        return "{type}(attr_name={attr_name!r}, unique={unique!r})".format(
-            attr_name=self.attr_name,
-            type=type(self).__name__,
-            unique=self.unique,
-        )
+        return f"{type(self).__name__}(attr_name={self.attr_name!r}, unique={self.unique!r})"
 
     def get_class(self, key: typing.Hashable) -> typing.Optional[type]:
         """
@@ -77,19 +72,13 @@ class ClassRegistry(BaseMutableRegistry):
         """
         if key in ["", None]:
             raise ValueError(
-                "Attempting to register class {cls} "
-                "with empty registry key {key!r}.".format(
-                    cls=class_.__name__,
-                    key=key,
-                ),
+                f"Attempting to register class {class_.__name__} "
+                "with empty registry key {key!r}."
             )
 
         if self.unique and (key in self._registry):
             raise RegistryKeyError(
-                "{cls} with key {key!r} is already registered.".format(
-                    cls=class_.__name__,
-                    key=key,
-                ),
+                f"{class_.__name__} with key {key!r} is already registered.",
             )
 
         self._registry[key] = class_
@@ -107,8 +96,7 @@ class ClassRegistry(BaseMutableRegistry):
 
 class SortedClassRegistry(ClassRegistry):
     """
-    A ClassRegistry that uses a function to determine sort order when
-    iterating.
+    A ClassRegistry that uses a function to determine sort order when iterating.
     """
 
     def __init__(
@@ -127,12 +115,11 @@ class SortedClassRegistry(ClassRegistry):
             You can also use :py:func:`functools.cmp_to_key`.
 
         :param attr_name:
-            If provided, :py:meth:`register` will automatically detect the key
-            to use when registering new classes.
+            If provided, :py:meth:`register` will automatically detect the key to use
+            when registering new classes.
 
         :param unique:
-            Determines what happens when two classes are registered with the
-            same key:
+            Determines what happens when two classes are registered with the same key:
 
             - ``True``: The second class will replace the first one.
             - ``False``: A ``ValueError`` will be raised.
@@ -152,7 +139,7 @@ class SortedClassRegistry(ClassRegistry):
         self,
     ) -> typing.Generator[typing.Tuple[typing.Hashable, type], None, None]:
         for key, class_, _ in sorted(
-            # Provide human-readable key and lookup key to the sorter...
+            # Provide both the human-readable key and actual lookup key to the sorter...
             (
                 (key, class_, self.gen_lookup_key(key))
                 for (key, class_) in super().items()
@@ -160,15 +147,15 @@ class SortedClassRegistry(ClassRegistry):
             key=self._sort_key,
             reverse=self.reverse,
         ):
-            # ... but for parity with other ClassRegistry types, only include
-            # the human-readable key in the result.
+            # ...but for parity with other ClassRegistry types, only include the
+            # human-readable key in the result.
             yield key, class_
 
     @staticmethod
     def create_sorter(sort_key: str) -> typing.Any:
         """
-        Given a sort key, creates a function that can be used to sort items
-        when iterating over the registry.
+        Given a sort key, creates a function that can be used to sort items when
+        iterating over the registry.
         """
 
         def sorter(a, b):

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -1,11 +1,8 @@
+__all__ = ["ClassRegistry", "SortedClassRegistry"]
+
 import typing
 from collections import OrderedDict
 from functools import cmp_to_key
-
-__all__ = [
-    "ClassRegistry",
-    "SortedClassRegistry",
-]
 
 from .base import BaseMutableRegistry, RegistryKeyError
 
@@ -168,12 +165,7 @@ class SortedClassRegistry(ClassRegistry):
             yield key, class_
 
     @staticmethod
-    def create_sorter(
-        sort_key: str,
-    ) -> typing.Callable[
-        [typing.Tuple[typing.Hashable, type], typing.Tuple[typing.Hashable, type]],
-        int,
-    ]:
+    def create_sorter(sort_key: str) -> typing.Any:
         """
         Given a sort key, creates a function that can be used to sort items
         when iterating over the registry.

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -4,25 +4,27 @@ This section covers more advanced or esoteric uses of ClassRegistry features.
 
 Registering Classes Automatically
 ---------------------------------
-Tired of having to add the ``register`` decorator to every class that you want
-to add to a class registry?  Surely there's a better way!
+Tired of having to add the ``register`` decorator to every class that you want to add to
+a class registry?  Surely there's a better way!
 
-ClassRegistry also provides an :py:func:`AutoRegister` metaclass that you can
-apply to a base class.  Any non-abstract subclass that extends that base class
-will be registered automatically.
+The answer is :py:func:`class_registry.base.AutoRegister`!
+
+Call ``AutoRegister()`` and pass in a registry, and it returns a base class.  Any
+non-abstract class that extends from that base class automatically gets added to the
+registry.
 
 Here's an example:
 
 .. code-block:: python
 
-   from abc import abstractmethod
+   from abc import ABC, abstractmethod
    from class_registry import ClassRegistry
-   from class_registry.auto_register import AutoRegister
+   from class_registry.base import AutoRegister
 
    pokedex = ClassRegistry('element')
 
-   # Note ``AutoRegister(pokedex)`` used as the metaclass here.
-   class Pokemon(metaclass=AutoRegister(pokedex)):
+   # Note ``AutoRegister(pokedex)`` used as a base class here, as well as ``ABC``.
+   class Pokemon(AutoRegister(pokedex), ABC):
         @abstractmethod
         def get_abilities(self):
             raise NotImplementedError()
@@ -79,6 +81,31 @@ because it is abstract.
 
       from inspect import isabstract
       assert not isabstract(ElectricPokemon)
+
+.. note::
+
+   In previous versions of ClassRegistry, ``AutoRegister`` returned a metaclass instead
+   of a base class.  The metaclass version of the function still exists at
+   :py:func:`class_registry.auto_register.AutoRegister`, but
+   `it is deprecated and will be removed in a future version of ClassRegistry <https://github.com/todofixthis/class-registry/issues/14>`.
+
+   If your code is still using the old ``AutoRegister`` function, you can change it like
+   this:
+
+   .. code-block:: python
+
+      # Deprecated:
+      from class_registry.auto_register import AutoRegister
+
+      class MyBaseClass(metaclass=AutoRegister(my_registry)):
+          ...
+
+      # Update to this:
+      from abc import ABC
+      from class_registry.base import AutoRegister
+
+      class MyBaseClass(AutoRegister(my_registry), ABC):
+          ...
 
 Patching
 --------

--- a/test/test_auto_register.py
+++ b/test/test_auto_register.py
@@ -1,9 +1,16 @@
-from abc import ABCMeta, abstractmethod as abstract_method
+"""
+Unit tests for :py:class:`class_registry.base.AutoRegister`, which replaces
+:py:class:`class_registry.auto_register.AutoRegister` (the latter returns a metaclass,
+whilst the former returns a base class).
+
+:see: https://github.com/todofixthis/class-registry/issues/14
+"""
+from abc import ABC, abstractmethod as abstract_method
 
 import pytest
 
 from class_registry import ClassRegistry
-from class_registry.auto_register import AutoRegister
+from class_registry.base import AutoRegister
 
 
 def test_auto_register():
@@ -12,19 +19,15 @@ def test_auto_register():
     """
     registry = ClassRegistry(attr_name="element")
 
-    # :py:func:`AutoRegister` is deprecated.
-    # :see: https://github.com/todofixthis/class-registry/issues/14
-    with pytest.deprecated_call():
-        # Note that we declare :py:func:`AutoRegister` as the metaclass
-        # for our base class.
-        class BasePokemon(metaclass=AutoRegister(registry)):
-            """
-            Abstract base class; will not get registered.
-            """
+    # Note that we declare :py:func:`AutoRegister` as a base class.
+    class BasePokemon(AutoRegister(registry), ABC):
+        """
+        Abstract base class; will not get registered.
+        """
 
-            @abstract_method
-            def get_abilities(self):
-                raise NotImplementedError()
+        @abstract_method
+        def get_abilities(self):
+            raise NotImplementedError()
 
     class Sandslash(BasePokemon):
         """
@@ -36,7 +39,7 @@ def test_auto_register():
         def get_abilities(self):
             return ["sand veil"]
 
-    class BaseEvolvingPokemon(BasePokemon, metaclass=ABCMeta):
+    class BaseEvolvingPokemon(BasePokemon, ABC):
         """
         Abstract subclass; will not get registered.
         """
@@ -71,12 +74,8 @@ def test_abstract_strict_definition():
     """
     registry = ClassRegistry(attr_name="element")
 
-    # :py:func:`AutoRegister` is deprecated.
-    # :see: https://github.com/todofixthis/class-registry/issues/14
-    with pytest.deprecated_call():
-
-        class FightingPokemon(metaclass=AutoRegister(registry)):
-            element = "fighting"
+    class FightingPokemon(AutoRegister(registry)):
+        element = "fighting"
 
     assert list(registry.items()) == [
         # :py:class:`FightingPokemon` does not define any
@@ -93,7 +92,4 @@ def test_error_attr_name_missing():
     registry = ClassRegistry()
 
     with pytest.raises(ValueError):
-        # :py:func:`AutoRegister` is deprecated.
-        # :see: https://github.com/todofixthis/class-registry/issues/14
-        with pytest.deprecated_call():
-            AutoRegister(registry)
+        AutoRegister(registry)

--- a/test/test_auto_register_deprecated.py
+++ b/test/test_auto_register_deprecated.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for the deprecated :py:class:`class_registry.auto_register.AutoRegister`
+function.
+
+This function is deprecated; use :py:class:`class_registry.base.AutoRegister` instead.
+:see: https://github.com/todofixthis/class-registry/issues/14
+"""
+from abc import ABC, abstractmethod as abstract_method
+
+import pytest
+
+from class_registry import ClassRegistry
+
+# noinspection PyDeprecation
+from class_registry.auto_register import AutoRegister
+
+
+def test_auto_register():
+    """
+    Using :py:func:`AutoRegister` to, well, auto-register classes.
+    """
+    registry = ClassRegistry(attr_name="element")
+
+    # :py:func:`AutoRegister` is deprecated.
+    # :see: https://github.com/todofixthis/class-registry/issues/14
+    with pytest.deprecated_call():
+        # Note that we declare :py:func:`AutoRegister` as the metaclass
+        # for our base class.
+        # noinspection PyDeprecation
+        class BasePokemon(metaclass=AutoRegister(registry)):
+            """
+            Abstract base class; will not get registered.
+            """
+
+            @abstract_method
+            def get_abilities(self):
+                raise NotImplementedError()
+
+    class Sandslash(BasePokemon):
+        """
+        Non-abstract subclass; will get registered automatically.
+        """
+
+        element = "ground"
+
+        def get_abilities(self):
+            return ["sand veil"]
+
+    class BaseEvolvingPokemon(BasePokemon, ABC):
+        """
+        Abstract subclass; will not get registered.
+        """
+
+        @abstract_method
+        def evolve(self):
+            raise NotImplementedError()
+
+    class Ekans(BaseEvolvingPokemon):
+        """
+        Non-abstract subclass; will get registered automatically.
+        """
+
+        element = "poison"
+
+        def get_abilities(self):
+            return ["intimidate", "shed skin"]
+
+        def evolve(self):
+            return "Congratulations! Your EKANS evolved into ARBOK!"
+
+    assert list(registry.items()) == [
+        # Note that only non-abstract classes got registered.
+        ("ground", Sandslash),
+        ("poison", Ekans),
+    ]
+
+
+def test_abstract_strict_definition():
+    """
+    If a class has no unimplemented abstract methods, it gets registered.
+    """
+    registry = ClassRegistry(attr_name="element")
+
+    # :py:func:`AutoRegister` is deprecated.
+    # :see: https://github.com/todofixthis/class-registry/issues/14
+    with pytest.deprecated_call():
+        # noinspection PyDeprecation
+        class FightingPokemon(metaclass=AutoRegister(registry)):
+            element = "fighting"
+
+    assert list(registry.items()) == [
+        # :py:class:`FightingPokemon` does not define any
+        # abstract methods, so it is not considered to be
+        # abstract!
+        ("fighting", FightingPokemon),
+    ]
+
+
+def test_error_attr_name_missing():
+    """
+    The registry doesn't have an ``attr_name``.
+    """
+    registry = ClassRegistry()
+
+    with pytest.raises(ValueError):
+        # :py:func:`AutoRegister` is deprecated.
+        # :see: https://github.com/todofixthis/class-registry/issues/14
+        with pytest.deprecated_call():
+            # noinspection PyDeprecation
+            AutoRegister(registry)

--- a/test/test_auto_register_meta.py
+++ b/test/test_auto_register_meta.py
@@ -12,16 +12,19 @@ def test_auto_register():
     """
     registry = ClassRegistry(attr_name="element")
 
-    # Note that we declare :py:func:`AutoRegister` as the metaclass
-    # for our base class.
-    class BasePokemon(metaclass=AutoRegister(registry)):
-        """
-        Abstract base class; will not get registered.
-        """
+    # :py:func:`AutoRegister` is deprecated.
+    # :see: https://github.com/todofixthis/class-registry/issues/14
+    with pytest.deprecated_call():
+        # Note that we declare :py:func:`AutoRegister` as the metaclass
+        # for our base class.
+        class BasePokemon(metaclass=AutoRegister(registry)):
+            """
+            Abstract base class; will not get registered.
+            """
 
-        @abstract_method
-        def get_abilities(self):
-            raise NotImplementedError()
+            @abstract_method
+            def get_abilities(self):
+                raise NotImplementedError()
 
     class Sandslash(BasePokemon):
         """
@@ -68,8 +71,12 @@ def test_abstract_strict_definition():
     """
     registry = ClassRegistry(attr_name="element")
 
-    class FightingPokemon(metaclass=AutoRegister(registry)):
-        element = "fighting"
+    # :py:func:`AutoRegister` is deprecated.
+    # :see: https://github.com/todofixthis/class-registry/issues/14
+    with pytest.deprecated_call():
+
+        class FightingPokemon(metaclass=AutoRegister(registry)):
+            element = "fighting"
 
     assert list(registry.items()) == [
         # :py:class:`FightingPokemon` does not define any
@@ -86,4 +93,7 @@ def test_error_attr_name_missing():
     registry = ClassRegistry()
 
     with pytest.raises(ValueError):
-        AutoRegister(registry)
+        # :py:func:`AutoRegister` is deprecated.
+        # :see: https://github.com/todofixthis/class-registry/issues/14
+        with pytest.deprecated_call():
+            AutoRegister(registry)


### PR DESCRIPTION
closes #14

## ⚠️ Deprecations
* `class_registry.auto_register.AutoRegister` is deprecated and will be removed in a future version of ClassRegistry.  Use `class_registry.base.AutoRegister` instead, and note that the latter returns a base class instead of a metaclass.  You'll need to update your classes like this:

    ```python
    # Deprecated:
    from class_registry.auto_register import AutoRegister
    class MyBaseClass(metaclass=AutoRegister(my_registry)):
        ...

    # Update to this:
    from abc import ABC
    from class_registry.base import AutoRegister
    class MyBaseClass(AutoRegister(my_registry), ABC):
        ...
    ```

## Minor changes
* Cleared out heaps of obsolete backwards-compatibility logic.