### PR TITLE
Gate releases with breaking changes on a migration guide

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -225,7 +225,7 @@ Only include the `[!WARNING]` block if there are breaking changes — but when i
 
 ## Writing a Migration Guide
 
-`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v5.rst`. Add it to the `docs/index.rst` toctree and link it from that page's upgrade alert, or readers never reach it.
+`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. Add it to the `docs/index.rst` toctree and link it from that page's upgrade alert, or readers never reach it.
 
 One page covers a whole major line: the move onto it, and any break shipped later within it. Say so in the opening paragraph — someone already on v6 has no reason to guess that "Upgrading to ClassRegistry v6" is where a 6.3.0 break is written down. Breaks after the major boundary get their own `Changes in v<version>` section; the major boundary itself is the page's main content.
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -42,7 +42,7 @@ A **breaking change** is anything that makes previously-working code fail — at
 
 It must:
 - **cover *this* release's breaking change.** A guide left over from an earlier release satisfies nothing — its existence is what makes this the easy check to fake. A break shipped in 6.3.0 gets its own section in `upgrading_to_v6.rst`, headed by the version that introduced it.
-- exist, be listed in the `docs/index.rst` toctree, and be linked from that page's upgrade alert.
+- exist, be listed in the `docs/index.rst` toctree, and be linked from the upgrade-alert listing in **both** `docs/index.rst` and `README.rst` — the two carry the same listing and drift apart easily.
 - follow _Writing a Migration Guide_ below.
 
 **If any of that is missing, the release stops here** — write it first.
@@ -51,7 +51,7 @@ Release notes do not satisfy this gate. They are read once, by people who alread
 
 ```bash
 ls docs/upgrading_to_v<major>.rst                        # exists
-rg 'upgrading_to_v<major>' docs/index.rst                # in toctree AND upgrade alert
+rg 'upgrading_to_v<major>' docs/index.rst README.rst     # index: toctree + alert; README: alert
 uv run make -C docs clean && uv run make -C docs html    # builds, and it isn't orphaned
 ```
 Then read the guide and confirm it covers this release's break. No command checks that for you.
@@ -225,7 +225,7 @@ Only include the `[!WARNING]` block if there are breaking changes — but when i
 
 ## Writing a Migration Guide
 
-`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. Add it to the `docs/index.rst` toctree and link it from that page's upgrade alert, or readers never reach it.
+`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. It stays unreachable until wired into three slots: the `docs/index.rst` toctree, and the upgrade-alert listing in **both** `docs/index.rst` and `README.rst`. Those two listings (one bullet per major upgrade) are duplicates that drift apart easily — add the new bullet to each, or the README goes stale.
 
 One page covers a whole major line: the move onto it, and any break shipped later within it. Say so in the opening paragraph — someone already on v6 has no reason to guess that "Upgrading to ClassRegistry v6" is where a 6.3.0 break is written down. Breaks after the major boundary get their own `Changes in v<version>` section; the major boundary itself is the page's main content.
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -245,7 +245,7 @@ Then add what the fix leads them into next:
 
 Verify every code sample and every error message by running it. Prose that merely sounds right is the recurring failure in this repo's documentation, and a migration guide is the worst place for it — its readers are already stuck.
 
-Before wiring the guide in, run two passes over the draft, modelled on the audience-surrogate review and quality pass in `phx:writing-release-notes`:
+Before wiring the guide in, run two passes over the draft:
 
 ### Audience-surrogate review
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -225,7 +225,7 @@ Only include the `[!WARNING]` block if there are breaking changes — but when i
 
 ## Writing a Migration Guide
 
-`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. It stays unreachable until wired into three slots: the `docs/index.rst` toctree, and the upgrade-alert listing in **both** `docs/index.rst` and `README.rst`. Those two listings (one bullet per major upgrade) are duplicates that drift apart easily — add the new bullet to each, or the README goes stale.
+`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. It stays unreachable until wired into three slots: the `docs/index.rst` toctree, and the upgrade-alert listing in **both** `docs/index.rst` and `README.rst`. Those listings (one bullet per major upgrade) are duplicates that drift apart easily — add the new bullet to each, or the README goes stale.
 
 One page covers a whole major line: the move onto it, and any break shipped later within it. Say so in the opening paragraph — someone already on v6 has no reason to guess that "Upgrading to ClassRegistry v6" is where a 6.3.0 break is written down. Breaks after the major boundary get their own `Changes in v<version>` section; the major boundary itself is the page's main content.
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -33,30 +33,42 @@ Based on the changes, recommend a semver bump:
 - **minor** — new features or behaviour changes, fully backwards-compatible
 - **patch** — bug fixes only
 
+### 5. Gate: breaking changes require a migration guide
+If this release has breaking changes, `docs/upgrading_to_v<major>.rst` **must already exist**, be listed in the `docs/index.rst` toctree, and be linked from that page's upgrade alert. **If it does not, the release stops here** — write it first, following the _Writing a Migration Guide_ section below.
+
+Release notes do not satisfy this gate. They are read once, by people who already know a release happened; the guide is what someone finds months later when their type checker starts failing and they don't yet know why.
+
+Verify all three, not just the first:
+```bash
+ls docs/upgrading_to_v<major>.rst                        # exists
+rg 'upgrading_to_v<major>' docs/index.rst                # in toctree AND upgrade alert
+uv run make -C docs clean && uv run make -C docs html    # builds, and it isn't orphaned
+```
+
 **Stop here. Get explicit confirmation of the release notes and version number before continuing.**
 
 ---
 
 ## Phase 2 — Publish (after confirmation)
 
-### 5. Bump version on `develop`
+### 6. Bump version on `develop`
 ```bash
 uv version <version>
 ```
 This updates `pyproject.toml` and re-locks `uv.lock` in one step. Commit both files and push to `develop`.
 
-### 6. Open release PR
+### 7. Open release PR
 ```bash
 gh pr create --base main --title "Release v<version>" --body-file release-<version>.md
 ```
 **Stop here. Wait for the user to confirm the PR is merged before continuing.**
 
-### 7. Switch to `main`
+### 8. Switch to `main`
 ```bash
 git checkout main && git pull
 ```
 
-### 8. Build
+### 9. Build
 ```bash
 uv sync --group=dev
 rm -f dist/*
@@ -64,14 +76,14 @@ uv build
 ```
 Sync first — pulling `main` may have brought in dependency changes. Artefacts land in `dist/`.
 
-### 9. Tag and push
+### 10. Tag and push
 ```bash
 git tag -a <version> -m "Release <version>"
 git push origin <version>
 ```
 `<version>` must match `pyproject.toml`.
 
-### 10. Create GitHub release
+### 11. Create GitHub release
 
 **a. Append checksums to the release notes file:**
 ```bash
@@ -106,24 +118,24 @@ gh release create <version> dist/* \
 ```
 `dist/*` picks up the `.whl`, `.tar.gz`, and `.sig` files.
 
-### 11. Upload to PyPI
+### 12. Upload to PyPI
 ```bash
 uv publish --username __token__
 ```
 
-### 12. Clean up
+### 13. Clean up
 ```bash
 rm release-<version>.md release-<version>.md.asc release-<version>-body.md
 git checkout develop && git pull
 ```
 
-### 13. Close related GitHub issues
+### 14. Close related GitHub issues
 For every issue referenced in the release notes, close it with a comment:
 ```bash
 gh issue close <number> --comment "Implemented in [v<version>](https://github.com/todofixthis/class-registry/releases/tag/<version>)."
 ```
 
-### 14. Rebase `develop` onto `main`
+### 15. Rebase `develop` onto `main`
 ```bash
 git rebase origin/main
 git push
@@ -144,6 +156,8 @@ Because `develop` now contains all of `main`'s commits, the histories no longer 
 > - {what changed}
 >   - {migration instructions}
 >   - {error you'll see if you don't migrate}
+>
+> Full migration guide: [Upgrading to ClassRegistry v{major}](https://class-registry.readthedocs.io/en/latest/upgrading_to_v{major}.html)
 
 ## New features
 ## Enhancements
@@ -160,7 +174,7 @@ Because `develop` now contains all of `main`'s commits, the histories no longer 
 # SHA256 Checksums
 ```
 
-Only include the `[!WARNING]` block if there are breaking changes. Omit any section that has no entries.
+Only include the `[!WARNING]` block if there are breaking changes — but when it is present, the migration guide link is **required**, not optional. Omit any section that has no entries.
 
 ### Grouping related items
 - **2–4 related bullets:** nest as a hierarchical sublist under the parent bullet
@@ -192,4 +206,28 @@ Only include the `[!WARNING]` block if there are breaking changes. Omit any sect
 > - `SomeClass.old_method()` removed
 >   - Replace with `SomeClass.new_method()`
 >   - You'll know you need to migrate if you see: `AttributeError: 'SomeClass' object has no attribute 'old_method'`
+>
+> Full migration guide: [Upgrading to ClassRegistry v6](https://class-registry.readthedocs.io/en/latest/upgrading_to_v6.html)
 ```
+
+---
+
+## Writing a Migration Guide
+
+`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v5.rst`. Add it to the `docs/index.rst` toctree and link it from that page's upgrade alert, or readers never reach it.
+
+Write for someone who upgraded, hit an error, and does not yet know a release caused it. They arrive by searching the error text — not by reading release notes.
+
+Each breaking change needs four things:
+
+1. **What changed**, in terms of what the developer wrote, not what the internals do.
+2. **The error they'll actually see** — copy it verbatim from the tool. Never paraphrase a compiler; they match on this text.
+3. **The fix**, as code.
+4. **Whether runtime behaviour changed.** If it didn't, say so plainly and early — it converts a panic into a chore.
+
+Then add what the fix leads them into next:
+
+- **Second-order traps.** A fix that lands people in a subtler failure needs that failure documented beside it, with its error text. The v6 guide's invariance trap is the model: the guide recommends `Hashable` as the escape hatch, so it also documents that `ClassRegistry[Foo]` won't pass to a `ClassRegistry[Foo, Hashable]` parameter.
+- **Facts stranded in ADRs.** ADRs are not in the toctree and readers never see them. If an ADR holds the only explanation of something a migrating developer needs, the guide is where it goes.
+
+Verify every code sample and every error message by running it. Prose that merely sounds right is the recurring failure in this repo's documentation, and a migration guide is the worst place for it — its readers are already stuck.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -34,16 +34,27 @@ Based on the changes, recommend a semver bump:
 - **patch** — bug fixes only
 
 ### 5. Gate: breaking changes require a migration guide
-If this release has breaking changes, `docs/upgrading_to_v<major>.rst` **must already exist**, be listed in the `docs/index.rst` toctree, and be linked from that page's upgrade alert. **If it does not, the release stops here** — write it first, following the _Writing a Migration Guide_ section below.
+A **breaking change** is anything that makes previously-working code fail — at runtime, or under a type checker. Undocumented behaviour someone relied on still counts; "only a couple of users" measures blast radius, not compatibility. If this release has none, skip to the stop below.
 
-Release notes do not satisfy this gate. They are read once, by people who already know a release happened; the guide is what someone finds months later when their type checker starts failing and they don't yet know why.
+**First, settle the version.** Step 4 defines minor and patch as *fully backwards-compatible*, so a breaking change in anything but a major contradicts it. When that happens, stop and put it to the developer: bump to major, or keep the smaller bump and record why in an ADR. Neither pick it for them nor draft around it — the answer decides which guide the rest of this step is about, and a release drafted for one version and linked to another ships broken.
 
-Verify all three, not just the first:
+**Then the guide.** One guide per major line, `docs/upgrading_to_v<major>.rst` — never a per-minor page. `<major>` is the major being released, or, for a break shipped in a minor or patch, the major line it lands on.
+
+It must:
+- **cover *this* release's breaking change.** A guide left over from an earlier release satisfies nothing — its existence is what makes this the easy check to fake. A break shipped in 6.3.0 gets its own section in `upgrading_to_v6.rst`, headed by the version that introduced it.
+- exist, be listed in the `docs/index.rst` toctree, and be linked from that page's upgrade alert.
+- follow _Writing a Migration Guide_ below.
+
+**If any of that is missing, the release stops here** — write it first.
+
+Release notes do not satisfy this gate. They are read once, by people who already know a release happened; the guide is what someone finds months later when their code breaks and they don't yet know why.
+
 ```bash
 ls docs/upgrading_to_v<major>.rst                        # exists
 rg 'upgrading_to_v<major>' docs/index.rst                # in toctree AND upgrade alert
 uv run make -C docs clean && uv run make -C docs html    # builds, and it isn't orphaned
 ```
+Then read the guide and confirm it covers this release's break. No command checks that for you.
 
 **Stop here. Get explicit confirmation of the release notes and version number before continuing.**
 
@@ -215,6 +226,8 @@ Only include the `[!WARNING]` block if there are breaking changes — but when i
 ## Writing a Migration Guide
 
 `docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v5.rst`. Add it to the `docs/index.rst` toctree and link it from that page's upgrade alert, or readers never reach it.
+
+One page covers a whole major line: the move onto it, and any break shipped later within it. Say so in the opening paragraph — someone already on v6 has no reason to guess that "Upgrading to ClassRegistry v6" is where a 6.3.0 break is written down. Breaks after the major boundary get their own `Changes in v<version>` section; the major boundary itself is the page's main content.
 
 Write for someone who upgraded, hit an error, and does not yet know a release caused it. They arrive by searching the error text — not by reading release notes.
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -42,7 +42,7 @@ A **breaking change** is anything that makes previously-working code fail — at
 
 It must:
 - **cover *this* release's breaking change.** A guide left over from an earlier release satisfies nothing — its existence is what makes this the easy check to fake. A break shipped in 6.3.0 gets its own section in `upgrading_to_v6.rst`, headed by the version that introduced it.
-- exist, be listed in the `docs/index.rst` toctree, and be linked from the upgrade-alert listing in **both** `docs/index.rst` and `README.rst` — the two carry the same listing and drift apart easily.
+- exist, be listed in the `docs/index.rst` toctree, and be linked from the upgrade-alert listing in **both** `docs/index.rst` and `README.rst` — the two carry the same listing and drift apart easily. The link syntax differs by file: `docs/index.rst` uses a Sphinx `:doc:` role targeting `upgrading_to_v<major>`; `README.rst` uses a relative link to the source, `` `Upgrading to ClassRegistry v<major> <docs/upgrading_to_v<major>.rst>`_ `` — the `:doc:` role renders as raw text on GitHub, where the README is read.
 - follow _Writing a Migration Guide_ below.
 
 **If any of that is missing, the release stops here** — write it first.
@@ -225,7 +225,7 @@ Only include the `[!WARNING]` block if there are breaking changes — but when i
 
 ## Writing a Migration Guide
 
-`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. It stays unreachable until wired into three slots: the `docs/index.rst` toctree, and the upgrade-alert listing in **both** `docs/index.rst` and `README.rst`. Those listings (one bullet per major upgrade) are duplicates that drift apart easily — add the new bullet to each, or the README goes stale.
+`docs/upgrading_to_v<major>.rst`, modelled on the existing `upgrading_to_v6.rst`. It stays unreachable until wired into three slots: the `docs/index.rst` toctree, and the upgrade-alert listing in **both** `docs/index.rst` and `README.rst`. The two listings (one bullet per major upgrade) drift apart easily — add the bullet to each, or the README goes stale. Their link syntax differs: `docs/index.rst` uses a Sphinx `:doc:` role targeting `upgrading_to_v<major>`; `README.rst` uses a relative link to the source, `` `Upgrading to ClassRegistry v<major> <docs/upgrading_to_v<major>.rst>`_ `` — `:doc:` renders as raw text on GitHub, where the README is read.
 
 One page covers a whole major line: the move onto it, and any break shipped later within it. Say so in the opening paragraph — someone already on v6 has no reason to guess that "Upgrading to ClassRegistry v6" is where a 6.3.0 break is written down. Breaks after the major boundary get their own `Changes in v<version>` section; the major boundary itself is the page's main content.
 
@@ -240,7 +240,17 @@ Each breaking change needs four things:
 
 Then add what the fix leads them into next:
 
-- **Second-order traps.** A fix that lands people in a subtler failure needs that failure documented beside it, with its error text. The v6 guide's invariance trap is the model: the guide recommends `Hashable` as the escape hatch, so it also documents that `ClassRegistry[Foo]` won't pass to a `ClassRegistry[Foo, Hashable]` parameter.
+- **Second-order traps.** A fix that lands people in a subtler failure needs that failure documented beside it, with its error text.
 - **Facts stranded in ADRs.** ADRs are not in the toctree and readers never see them. If an ADR holds the only explanation of something a migrating developer needs, the guide is where it goes.
 
 Verify every code sample and every error message by running it. Prose that merely sounds right is the recurring failure in this repo's documentation, and a migration guide is the worst place for it — its readers are already stuck.
+
+Before wiring the guide in, run two passes over the draft, modelled on the audience-surrogate review and quality pass in `phx:writing-release-notes`:
+
+### Audience-surrogate review
+
+Dispatch one subagent on the main model (a reasoning task, not a cheap one), given only the draft and cast as the reader above. It must resolve its problem from the guide alone and flag every place it stays stuck: an error string it can't match verbatim against what a tool emits, a fix it can't apply without knowledge the guide assumes, unexplained jargon, a missing second-order trap or stranded-ADR fact. Address the feedback before continuing.
+
+### Conciseness pass
+
+Tighten the reviewed draft: cut repetition, merge overlapping fixes, drop hedging and prose that restates a code sample. The surrogate review optimises for completeness and leaves the draft longer than it needs to be, so weigh each addition and keep only what earns its place. Never trim two things for length: **verbatim error text and code fixes** — readers match on them — and any **migration step**. Then, since this repo uses NZ English, run `phx:nz-english` over the result.

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Upgrading from an Earlier Version
    usually easier to upgrade through each major release incrementally (e.g. v4 -> v5 ->
    v6) rather than make all the changes for each major release all at once.
 
-   - v5 -> v6: :doc:`upgrading_to_v6`
-   - v4 -> v5: :doc:`upgrading_to_v5`
+   - v5 -> v6: `Upgrading to ClassRegistry v6 <docs/upgrading_to_v6.rst>`_
+   - v4 -> v5: `Upgrading to ClassRegistry v5 <docs/upgrading_to_v5.rst>`_
 
 Getting Started
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -13,14 +13,19 @@ At the intersection of the Registry and Factory patterns lies the ``ClassRegistr
   extensible by 3rd-party libraries!
 - And more!
 
-Upgrading from ClassRegistry v4
--------------------------------
-.. important::
+Upgrading from an Earlier Version
+----------------------------------
+.. warning::
 
-   ClassRegistry v5 introduces some changes that can break code that was previously
-   using ClassRegistry v4.  If you are upgrading from ClassRegistry v4 to ClassRegistry
-   v5, please read `Upgrading to ClassRegistry v5 <./docs/upgrading_to_v5.rst>`_.
+   Major releases of ClassRegistry introduce breaking changes. If you are upgrading to a
+   new major version of ClassRegistry, please consult the migration docs.
 
+   If you are upgrading through more than one major version (e.g. v4 -> v6), it's
+   usually easier to upgrade through each major release incrementally (e.g. v4 -> v5 ->
+   v6) rather than make all the changes for each major release all at once.
+
+   - v5 -> v6: :doc:`upgrading_to_v6`
+   - v4 -> v5: :doc:`upgrading_to_v5`
 
 Getting Started
 ---------------


### PR DESCRIPTION
## Why

PR #101 added `docs/upgrading_to_v6.rst` because an audience-surrogate review found the v6 migration instructions were unreachable: the toctree and the front-page upgrade alert both pointed only at v5, so anyone hitting the new type error had no path to the answer. Its verdict was *"Migrating to v6.0.0: no — not because the guidance is bad, but because I would never find it."*

The instructions existed. Nothing made them findable. This closes that hole for every future major.

## What

- **A gate in Phase 1.** A release with breaking changes stops unless `docs/upgrading_to_v<major>.rst` exists, is in the toctree, *and* is linked from the front-page upgrade alert. All three are checked — the guide being orphaned is the same failure as it being absent.
- **A required slot in the template.** The breaking-changes alert now carries a migration guide link. The gate is a rule someone can forget; the slot is a blank in the thing they are already filling in.
- **A `Writing a Migration Guide` section.** What a guide owes its reader: the verbatim error text (they arrive by searching it), the fix, whether runtime behaviour changed, plus second-order traps and facts otherwise stranded in ADRs where no reader will see them.

Phase 2's steps are renumbered 6–15. Nothing referenced them by number.

## Verification

Tested per `superpowers:writing-skills` — a scenario (v7.0.0, two breaking removals, no guide written), same model, run against the skill before and after.

**Before:** a thorough Phase 1 — 12-item checklist covering GPG keys, PyPI tokens, CI. Migration guide mentioned **zero** times. It wrote migration *instructions* inline, because the template has a slot for those, and stopped there.

**After:** first action was checking for the guide, reporting *"no `upgrading_to_v6.rst` (or v7) exists, and none is referenced in `docs/index.rst`'s toctree or upgrade alert."* It produced a **"Migration-guide gate (Phase 1 step 5 — currently failing)"** section blocking Phase 2, and included the required link in the alert.

Both runs independently flagged that 5.2.2 → 7.0.0 skips a major, so the gate didn't crowd out existing judgement. The after-run also challenged its own asserted `ImportError` — noting a deleted module raises `ModuleNotFoundError` — which is the "verify by running it" guidance doing its job.

## Note

Unrelated to #101's review feedback, so it's on its own branch to keep that PR reviewable against its ten comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
