### PR TITLE
Pin CI actions to commit digests 🧭

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install system dependencies
@@ -43,11 +43,11 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: "pyproject.toml"
       - name: Install system dependencies
@@ -65,11 +65,11 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: "pyproject.toml"
       - name: Install system dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
## Kaupapa

Harden the CI supply chain by pinning every GitHub Action to an immutable commit SHA instead of a mutable tag.

Before this change, `build.yml` referenced actions by floating tags (`actions/checkout@v7`, `astral-sh/setup-uv@v8.3.2`, `actions/setup-python@v7`). A tag is mutable: whoever controls (or compromises) the upstream repo can repoint it at arbitrary code, which our runners then execute on the next push — the exact mechanism behind the March 2025 `tj-actions/changed-files` compromise. A commit digest cannot be moved out from under us.

## What changed

- **Pinned all three actions to full commit SHAs** across the `build`, `type-check`, and `docs` jobs, each with a trailing `# vX.Y.Z` comment so the human-readable version stays visible and auditable:
  - `actions/checkout` → `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1)
  - `astral-sh/setup-uv` → `11f9893b081a58869d3b5fccaea48c9e9e46f990` (v8.3.2)
  - `actions/setup-python` → `5fda3b95a4ea91299a34e894583c3862153e4b97` (v7.0.0)
- **Added `helpers:pinGitHubActionDigests` to the Renovate config** so future updates arrive as digest pins (SHA + refreshed version comment) rather than reverting to floating tags. Renovate keeps bumping them — you still get updates, just reviewable and immutable.

## Notes

- Follow-up to #109 (setup-python v6 → v7); this pins the v7 digest that merge landed on.
- No functional change to CI behaviour — same action versions, just referenced immutably.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8