### PR TITLE
Fix cache iteration when gen_lookup_key is overridden

### DIFF
--- a/src/class_registry/cache.py
+++ b/src/class_registry/cache.py
@@ -81,7 +81,8 @@ class ClassRegistryInstanceCache(
 
         If a key has not been accessed yet, it will not be included.
         """
-        for lookup_key in self._registry.keys():
+        for public_key in self._registry.keys():
+            lookup_key = self._registry.gen_lookup_key(public_key)
             for cache_key in self._key_map[lookup_key]:
                 yield self._cache[cache_key]
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 
 from class_registry import ClassRegistry
@@ -81,3 +83,24 @@ def test_len(
     cache.__getitem__("grass")
 
     assert len(cache) == 2
+
+
+def test_iter_with_customised_lookup_key() -> None:
+    """
+    Iterating over a cache still yields cached instances when the wrapped
+    registry overrides ``gen_lookup_key`` with a non-identity function.
+    """
+
+    class FoldingRegistry(ClassRegistry[Pokemon]):
+        def gen_lookup_key(self, key: typing.Hashable) -> typing.Hashable:
+            return key.casefold() if isinstance(key, str) else key
+
+    registry = FoldingRegistry()
+    registry.register("Grass")(Bulbasaur)
+    registry.register("Water")(Squirtle)
+
+    cache = ClassRegistryInstanceCache[Pokemon](registry)
+    cache.__getitem__("Grass")
+    cache.__getitem__("Water")
+
+    assert {type(instance) for instance in cache} == {Bulbasaur, Squirtle}


### PR DESCRIPTION
## Summary

`ClassRegistryInstanceCache.__iter__` walks the wrapped registry's public
keys and uses them directly to index the cache's key map, which is keyed
by lookup keys instead. With the default identity `gen_lookup_key`, the
two happen to match, so this stayed hidden. Once a registry overrides
`gen_lookup_key` — the case-folding pattern `docs/advanced_topics.rst`
teaches — the two key spaces diverge and iteration silently yields
nothing, even though `len()` and direct lookups work fine.

This PR converts each public key through `gen_lookup_key` before
indexing the key map, so iteration matches the keys `__getitem__`
already resolves correctly. `__iter__` was the only method indexing the
key map with a public key; `__getitem__` and `warm_cache` already went
through `gen_lookup_key`, and `__len__` doesn't touch the key map.

## Changes

- Fix `ClassRegistryInstanceCache.__iter__` to route public keys through
  `gen_lookup_key` before matching them against the cache's key map.
- Add a regression test using a case-folding registry.

## Test plan

- [x] Confirmed the new test fails on the pre-fix code (empty iteration)
      and passes once the fix is applied
- [x] `uv run pytest` — 44 passed (was 43; new regression test included)
- [x] `uv run mypy src test` — no issues
- [x] `uv run ruff check` — all checks passed

Fixes #106

🤖 _Generated with [Claude Code](https://claude.com/claude-code) — Claude Sonnet 5_


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9rydoGMPXM2o7VXANGWfy)_