### PR TITLE
Rename uv's native-tls to system-certs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,4 +103,4 @@ runner = "uv-venv-lock-runner"
 [tool.uv]
 keyring-provider = "subprocess"
 # Fix SSL errors when running in Leash containers
-native-tls = true
+system-certs = true


### PR DESCRIPTION
## Summary
- Rename the deprecated `native-tls` setting to `system-certs` in `[tool.uv]`; uv warns the old name will be removed in a future release. No behaviour change.

## Test plan
- [x] `uv lock --check` (uv 0.12.7) — the `native-tls` deprecation warning is gone; resolves cleanly with no lockfile drift.

🤖 _Generated with [Claude Code](https://claude.com/claude-code) — Claude Sonnet 5_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjiFkHC6eer4CHctZ4Fa1J)_