### PR TITLE
Fix release skill's dist cleanup and refs

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -82,10 +82,14 @@ git checkout main && git pull
 ### 9. Build
 ```bash
 uv sync --group=dev
-rm -f dist/*
+rm -rf dist
 uv build
 ```
-Sync first — pulling `main` may have brought in dependency changes. Artefacts land in `dist/`.
+Sync first — pulling `main` may have brought in dependency changes. Artefacts
+land in `dist/`. Nothing under `dist/` is tracked, so removing the whole
+directory is safe — and necessary: under zsh `rm -f dist/*` aborts with `no
+matches found` when `dist/` is empty or absent, and otherwise skips uv's
+`.gitignore`. `uv build` recreates both.
 
 ### 10. Tag and push
 ```bash
@@ -98,7 +102,7 @@ git push origin <version>
 
 **a. Append checksums to the release notes file:**
 ```bash
-sha256sum dist/phx_class_registry-* >> release-<version>.md
+shasum -a 256 dist/phx_class_registry-* >> release-<version>.md
 ```
 
 **b. GPG-sign the document and each build artefact:**
@@ -131,14 +135,32 @@ gh release create <version> dist/* \
 
 ### 12. Upload to PyPI
 ```bash
-uv publish --username __token__
+# Publishes only if the keyring can supply the token
+keyring get https://upload.pypi.org/legacy/ __token__ >/dev/null 2>&1 && \
+  uv publish --username __token__
 ```
+The token comes from the developer's keyring: `[tool.uv]` in `pyproject.toml`
+sets `keyring-provider = "subprocess"`, so uv shells out to a `keyring`
+executable on `PATH`. Run the check first — it exits non-zero when the keyring
+cannot supply the token, and prints nothing either way. Never echo the token to
+confirm it; that puts a live credential in the transcript.
+
+**If the check fails, stop here** and ask the developer to set
+`UV_PUBLISH_TOKEN` (which takes precedence over the keyring) and run the publish
+themselves. You cannot export it into their shell, and discovering this by
+running the upload means failing the release's one irreversible step.
 
 ### 13. Clean up
 ```bash
-rm release-<version>.md release-<version>.md.asc release-<version>-body.md
+rm -f release-<version>.md release-<version>.md.asc release-<version>-body.md
+rm -rf dist
 git checkout develop && git pull
 ```
+`-f` so a re-run does not fail on a file already removed. `dist` goes too — its
+artefacts and `.sig` files are on the GitHub release and PyPI by now. To correct
+a release afterwards, fetch those assets back with `gh release download
+<version>`: a rebuilt wheel may not be byte-identical, so its checksums would
+disagree with the published notes.
 
 ### 14. Close related GitHub issues
 For every issue referenced in the release notes, close it with a comment:


### PR DESCRIPTION
## What

Ports the release-skill fixes from [todofixthis/paddock#9](https://github.com/todofixthis/paddock/pull/9), found by running that skill to cut a paddock release, into this project's own `release` skill:

- Build step: `rm -f dist/*` → `rm -rf dist`. The old glob aborted under zsh when `dist/` was empty or absent, and skipped uv's generated `.gitignore` even when it matched.
- Checksums: `sha256sum` → `shasum -a 256` — the former is GNU-only and absent on a macOS host.
- Gate the PyPI publish on a keyring check, and document where the token comes from (`[tool.uv] keyring-provider = "subprocess"`), instead of discovering its absence at the release's one irreversible step.
- Clean up with a forgiving `rm -f` that survives a re-run, and remove the build directory so signatures don't outlive the release.

This skill's GitHub-release sub-steps were already lettered correctly (a–d), so that part of the source fix didn't apply.

## Not ported

The paddock commit also repoints the tag step at `__init__.py` because paddock's version is `dynamic` in `pyproject.toml`. This project's version is static in `pyproject.toml` (set by `uv version`), so the existing wording is already correct — not changed.

## Verification

Not yet exercised end to end — these are documentation-only changes to a skill; the next release run is the real test, same as for the source commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A49i8Pr9YVQtbvUDw4daPd

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49i8Pr9YVQtbvUDw4daPd)_